### PR TITLE
doc: document that namespace are illustrative 

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,11 @@ Several implementer questions come up around how `import:` URLs are envisioned t
 
 The high-level summary is that any fetch of an `import:` URL should be thought of as sugar for a series of if-then-else statements that in turn fetch the mapped-to URLs. For example, each fetch will pass through the service worker, until one succeeds.
 
+## Namespaces
+
+This proposal and the reference implementation, use the namespace `@std/` for illustrative purposes only. This proposal is generic and would
+be able to work with a variety of approaches to namespaces.
+
 ## Acknowledgments
 
 This document originated out of a day-long sprint involving [@domenic](https://github.com/domenic), [@hiroshige-g](https://github.com/hiroshige-g), [@justinfagnani](https://github.com/justinfagnani), [@MylesBorins](https://github.com/MylesBorins), and [@nyaxt](https://github.com/nyaxt). Since then, [@guybedford](https://github.com/guybedford) has been instrumental in prototyping and driving forward discussion on this proposal.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ import { StorageArea } from "@std/kv-storage";
 
 will first try to resolve to `@std/kv-storage`, i.e. the browser's built-in implementation of KV storage. If that fails, e.g. because the browser does not implement KV storage, then instead it will fetch the polyfill, at `/node_modules/als-polyfill/index.mjs`.
 
+_Note: the usage of the `@std/` prefix for built-in module examples is for illustrative purposes only. (Indeed, the KV Storage specification currently uses a `std:` prefix.) This proposal is generic, and would be able to work with any built-in module prefix._
+
 #### For built-in modules, in browsers without import maps
 
 The goal of the previous example is to use a polyfill in older browsers, but the built-in module in newer browsers. But it falls down in the case of browsers that are old enough to not support import maps at all. (That is, all of today's currently-shipping browsers.) In such cases, the statement `import { StorageArea } from "@std/kv-storage"` will always fail, with no chance to remap it.
@@ -811,11 +813,6 @@ We can easily start by disallowing such uses of `import:` URLs, and expanding to
 Several implementer questions come up around how `import:` URLs are envisioned to interact with other loading infrastructure, for example service workers. Initial attempts to answer these sorts of questions are in [the proto-spec](./spec.md).
 
 The high-level summary is that any fetch of an `import:` URL should be thought of as sugar for a series of if-then-else statements that in turn fetch the mapped-to URLs. For example, each fetch will pass through the service worker, until one succeeds.
-
-## Namespaces
-
-This proposal and the reference implementation, use the namespace `@std/` for illustrative purposes only. This proposal is generic and would
-be able to work with a variety of approaches to namespaces.
 
 ## Acknowledgments
 


### PR DESCRIPTION
This proposal is currently using the `@${namespace}/` idiom, as currently
used by npm. We are in the process of discussing namespaces in Node.js core
and are debating between `@{namespace}/` and `${namespace}:`. This PR
changes the docs to use the url like schema which we can point to as
an example of cross ecosystem adoption of the pattern.

Refs: https://github.com/nodejs/node/pull/21551