### PR TITLE
nit: one example uses key 'modules' instead of 'imports'

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ Multiple `<script type="importmap">`s are allowed on the page. (See previous dis
 
 ```js
 const result = {
-  modules: { ...a.modules, ...b.modules },
+  imports: { ...a.imports, ...b.imports },
   scopes: { ...a.scopes, ...b.scopes }
 };
 ```


### PR DESCRIPTION
Looks like this was missed in dd797075731c43346b14189db1fe20bb8d6ae287