### PR TITLE
Make most-specific specifier key win

### DIFF
--- a/reference-implementation/__tests__/resolving.js
+++ b/reference-implementation/__tests__/resolving.js
@@ -203,4 +203,23 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
       expect(resolveUnderTest('/test')).toMatchURL('https://example.com/lib/test2.mjs');
     });
   });
+
+  describe('Overlapping entries with trailing slashes', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "a": "/1",
+        "a/": "/2/",
+        "a/b": "/3",
+        "a/b/": "/4/"
+      }
+    }`);
+
+    it('should favor the most-specific key', () => {
+      expect(resolveUnderTest('a')).toMatchURL('https://example.com/1');
+      expect(resolveUnderTest('a/')).toMatchURL('https://example.com/2/');
+      expect(resolveUnderTest('a/b')).toMatchURL('https://example.com/3');
+      expect(resolveUnderTest('a/b/')).toMatchURL('https://example.com/4/');
+      expect(resolveUnderTest('a/b/c')).toMatchURL('https://example.com/4/c');
+    });
+  });
 });

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -25,6 +25,12 @@ exports.parseFromString = (input, baseURL) => {
     normalizedImports = normalizeSpecifierMap(parsed.imports, baseURL);
   }
 
+  const sortedAndNormalizedImports = {};
+  const sortedImportsKeys = Object.keys(normalizedImports).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedImportsKeys) {
+    sortedAndNormalizedImports[key] = normalizedImports[key];
+  }
+
   const normalizedScopes = {};
   if ('scopes' in parsed) {
     for (const [scopePrefix, specifierMap] of Object.entries(parsed.scopes)) {
@@ -49,7 +55,7 @@ exports.parseFromString = (input, baseURL) => {
 
   // Always have these two keys, and exactly these two keys, in the result.
   return {
-    imports: normalizedImports,
+    imports: sortedAndNormalizedImports,
     scopes: normalizedScopes
   };
 };
@@ -121,4 +127,18 @@ function normalizeAddress(address, baseURL) {
 
 function isJSONObject(value) {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function longerLengthThenCodeUnitOrder(a, b) {
+  return compare(b.length, a.length) || compare(a, b);
+}
+
+function compare(a, b) {
+  if (a > b) {
+    return 1;
+  }
+  if (b > 1) {
+    return -1;
+  }
+  return 0;
 }

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -137,7 +137,7 @@ function compare(a, b) {
   if (a > b) {
     return 1;
   }
-  if (b > 1) {
+  if (b > a) {
     return -1;
   }
   return 0;


### PR DESCRIPTION
In particular, this matters in cases involving trailing-slash specifiers. Closes #102.

/cc @hiroshige as I implemented this notably different than https://chromium-review.googlesource.com/c/chromium/src/+/1475049.