### PR TITLE
Reference implementation of scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,6 @@ Scopes "inherit" from each other in an intentionally-simple manner, merging but 
       "a": "/a-2.mjs"
     },
     "/scope2/scope3/": {
-      "a": "/a-3.mjs",
       "b": "/b-3.mjs"
     }
   }
@@ -411,7 +410,7 @@ would give the following resolutions:
 |b        |/scope2/foo.mjs        |/b-1.mjs      |
 |c        |/scope2/foo.mjs        |/c-1.mjs      |
 |         |                       |              |
-|a        |/scope2/scope3/foo.mjs |/a-3.mjs      |
+|a        |/scope2/scope3/foo.mjs |/a-2.mjs      |
 |b        |/scope2/scope3/foo.mjs |/b-3.mjs      |
 |c        |/scope2/scope3/foo.mjs |/c-1.mjs      |
 

--- a/reference-implementation/__tests__/helpers/parsing.js
+++ b/reference-implementation/__tests__/helpers/parsing.js
@@ -20,7 +20,7 @@ exports.expectSpecifierMap = (input, baseURL, output, warnings = []) => {
 exports.expectScopes = (inputArray, baseURL, outputArray, warnings = []) => {
   const checkWarnings = testWarningHandler(warnings);
 
-  const inputScopesAsStrings = inputArray.map(scopePrefix => `"${scopePrefix}": {}`);
+  const inputScopesAsStrings = inputArray.map(scopePrefix => `${JSON.stringify(scopePrefix)}: {}`);
   const inputString = `{ "scopes": { ${inputScopesAsStrings.join(', ')} } }`;
 
   const outputScopesObject = {};

--- a/reference-implementation/__tests__/parsing-scope-keys.js
+++ b/reference-implementation/__tests__/parsing-scope-keys.js
@@ -1,7 +1,7 @@
 'use strict';
 const { expectScopes } = require('./helpers/parsing.js');
 
-describe('Relative URL scope prefixes', () => {
+describe('Relative URL scope keys', () => {
   it('should work with no prefix', () => {
     expectScopes(
       ['foo'],
@@ -30,17 +30,39 @@ describe('Relative URL scope prefixes', () => {
     );
   });
 
-  it('should work with an empty string scope prefix', () => {
+  it('should work with an empty string scope key', () => {
     expectScopes(
       [''],
       'https://base.example/path1/path2/path3',
       ['https://base.example/path1/path2/path3']
     );
   });
+
+  it('should work with / suffixes', () => {
+    expectScopes(
+      ['foo/', './foo/', '../foo/', '/foo/', '/foo//'],
+      'https://base.example/path1/path2/path3',
+      [
+        'https://base.example/path1/path2/foo/',
+        'https://base.example/path1/path2/foo/',
+        'https://base.example/path1/foo/',
+        'https://base.example/foo/',
+        'https://base.example/foo//'
+      ]
+    );
+  });
+
+  it('should deduplicate based on URL parsing rules', () => {
+    expectScopes(
+      ['foo/\\', 'foo//', 'foo\\\\'],
+      'https://base.example/path1/path2/path3',
+      ['https://base.example/path1/path2/foo//']
+    );
+  });
 });
 
-describe('Absolute URL scope prefixes', () => {
-  it('should only accept absolute URL scope prefixes with fetch schemes', () => {
+describe('Absolute URL scope keys', () => {
+  it('should only accept absolute URL scope keys with fetch schemes', () => {
     expectScopes(
       [
         'about:good',
@@ -76,7 +98,7 @@ describe('Absolute URL scope prefixes', () => {
     );
   });
 
-  it('should parse absolute URL scope prefixes, ignoring unparseable ones', () => {
+  it('should parse absolute URL scope keys, ignoring unparseable ones', () => {
     expectScopes(
       [
         'https://ex ample.org/',
@@ -85,7 +107,7 @@ describe('Absolute URL scope prefixes', () => {
         'https:example.org',
         'https://///example.com///',
         'https://example.net',
-        'https://ex%41mple.com/',
+        'https://ex%41mple.com/foo/',
         'https://example.com/%41'
       ],
       'https://base.example/path1/path2/path3',
@@ -93,7 +115,7 @@ describe('Absolute URL scope prefixes', () => {
         'https://base.example/path1/path2/example.org', // tricky case! remember we have a base URL
         'https://example.com///',
         'https://example.net/',
-        'https://example.com/',
+        'https://example.com/foo/',
         'https://example.com/%41'
       ]
     );

--- a/reference-implementation/__tests__/resolving-scopes.js
+++ b/reference-implementation/__tests__/resolving-scopes.js
@@ -11,21 +11,79 @@ function makeResolveUnderTest(mapString) {
 }
 
 describe('Mapped using scope instead of "imports"', () => {
-  const inTwoScopesURL = new URL('https://example.com/js/app.mjs');
-  const inOneScopeURL = new URL('https://example.com/app.mjs');
+  const jsNonDirURL = new URL('https://example.com/js');
+  const inJSDirURL = new URL('https://example.com/js/app.mjs');
+  const topLevelURL = new URL('https://example.com/app.mjs');
 
   it('should fail when the mapping is to an empty array', () => {
     const resolveUnderTest = makeResolveUnderTest(`{
       "scopes": {
-        "/js": {
+        "/js/": {
           "moment": null,
           "lodash": []
         }
       }
     }`);
 
-    expect(() => resolveUnderTest('moment')).toThrow(TypeError);
-    expect(() => resolveUnderTest('lodash')).toThrow(TypeError);
+    expect(() => resolveUnderTest('moment', inJSDirURL)).toThrow(TypeError);
+    expect(() => resolveUnderTest('lodash', inJSDirURL)).toThrow(TypeError);
+  });
+
+  describe('Exact vs. prefix based matching', () => {
+    it('should match correctly when both are in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          },
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      }`);
+
+      expect(resolveUnderTest('moment', jsNonDirURL)).toMatchURL('https://example.com/only-triggered-by-exact/moment');
+      expect(resolveUnderTest('moment/foo', jsNonDirURL)).toMatchURL('https://example.com/only-triggered-by-exact/moment/foo');
+
+      expect(resolveUnderTest('moment', inJSDirURL)).toMatchURL('https://example.com/triggered-by-any-subpath/moment');
+      expect(resolveUnderTest('moment/foo', inJSDirURL)).toMatchURL('https://example.com/triggered-by-any-subpath/moment/foo');
+    });
+
+    it('should match correctly when only an exact match is in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js": {
+            "moment": "/only-triggered-by-exact/moment",
+            "moment/": "/only-triggered-by-exact/moment/"
+          }
+        }
+      }`);
+
+      expect(resolveUnderTest('moment', jsNonDirURL)).toMatchURL('https://example.com/only-triggered-by-exact/moment');
+      expect(resolveUnderTest('moment/foo', jsNonDirURL)).toMatchURL('https://example.com/only-triggered-by-exact/moment/foo');
+
+      expect(() => resolveUnderTest('moment', inJSDirURL)).toThrow(TypeError);
+      expect(() => resolveUnderTest('moment/foo', inJSDirURL)).toThrow(TypeError);
+    });
+
+    it('should match correctly when only a prefix match is in the map', () => {
+      const resolveUnderTest = makeResolveUnderTest(`{
+        "scopes": {
+          "/js/": {
+            "moment": "/triggered-by-any-subpath/moment",
+            "moment/": "/triggered-by-any-subpath/moment/"
+          }
+        }
+      }`);
+
+      expect(() => resolveUnderTest('moment', jsNonDirURL)).toThrow(TypeError);
+      expect(() => resolveUnderTest('moment/foo', jsNonDirURL)).toThrow(TypeError);
+
+      expect(resolveUnderTest('moment', inJSDirURL)).toMatchURL('https://example.com/triggered-by-any-subpath/moment');
+      expect(resolveUnderTest('moment/foo', inJSDirURL)).toMatchURL('https://example.com/triggered-by-any-subpath/moment/foo');
+    });
   });
 
   describe('Package-like scenarios', () => {
@@ -42,7 +100,7 @@ describe('Mapped using scope instead of "imports"', () => {
         "/": {
           "moment": "/node_modules_3/moment/src/moment.js"
         },
-        "/js": {
+        "/js/": {
           "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
           "lodash-dot/": "./node_modules_2/lodash-es/",
           "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
@@ -52,27 +110,27 @@ describe('Mapped using scope instead of "imports"', () => {
     }`);
 
     it('should resolve scoped and not cascade', () => {
-      expect(resolveUnderTest('lodash-dot', inTwoScopesURL)).toMatchURL('https://example.com/app/node_modules_2/lodash-es/lodash.js');
-      expect(resolveUnderTest('lodash-dotdot', inTwoScopesURL)).toMatchURL('https://example.com/node_modules_2/lodash-es/lodash.js');
-      expect(resolveUnderTest('lodash-dot/foo', inTwoScopesURL)).toMatchURL('https://example.com/app/node_modules_2/lodash-es/foo');
-      expect(resolveUnderTest('lodash-dotdot/foo', inTwoScopesURL)).toMatchURL('https://example.com/node_modules_2/lodash-es/foo');
+      expect(resolveUnderTest('lodash-dot', inJSDirURL)).toMatchURL('https://example.com/app/node_modules_2/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dotdot', inJSDirURL)).toMatchURL('https://example.com/node_modules_2/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dot/foo', inJSDirURL)).toMatchURL('https://example.com/app/node_modules_2/lodash-es/foo');
+      expect(resolveUnderTest('lodash-dotdot/foo', inJSDirURL)).toMatchURL('https://example.com/node_modules_2/lodash-es/foo');
     });
 
     it('should apply best scope match', () => {
-      expect(resolveUnderTest('moment', inOneScopeURL)).toMatchURL('https://example.com/node_modules_3/moment/src/moment.js');
+      expect(resolveUnderTest('moment', topLevelURL)).toMatchURL('https://example.com/node_modules_3/moment/src/moment.js');
     });
 
     it('should fallback to imports', () => {
-      expect(resolveUnderTest('moment/foo', inOneScopeURL)).toMatchURL('https://example.com/node_modules/moment/src/foo');
-      expect(resolveUnderTest('lodash-dot', inOneScopeURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/lodash.js');
-      expect(resolveUnderTest('lodash-dotdot', inOneScopeURL)).toMatchURL('https://example.com/node_modules/lodash-es/lodash.js');
-      expect(resolveUnderTest('lodash-dot/foo', inOneScopeURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/foo');
-      expect(resolveUnderTest('lodash-dotdot/foo', inOneScopeURL)).toMatchURL('https://example.com/node_modules/lodash-es/foo');
+      expect(resolveUnderTest('moment/foo', topLevelURL)).toMatchURL('https://example.com/node_modules/moment/src/foo');
+      expect(resolveUnderTest('lodash-dot', topLevelURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dotdot', topLevelURL)).toMatchURL('https://example.com/node_modules/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dot/foo', topLevelURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/foo');
+      expect(resolveUnderTest('lodash-dotdot/foo', topLevelURL)).toMatchURL('https://example.com/node_modules/lodash-es/foo');
     });
 
     it('should still fail for package-like specifiers that are not declared', () => {
-      expect(() => resolveUnderTest('underscore/', inTwoScopesURL)).toThrow(TypeError);
-      expect(() => resolveUnderTest('underscore/foo', inTwoScopesURL)).toThrow(TypeError);
+      expect(() => resolveUnderTest('underscore/', inJSDirURL)).toThrow(TypeError);
+      expect(() => resolveUnderTest('underscore/foo', inJSDirURL)).toThrow(TypeError);
     });
   });
 });

--- a/reference-implementation/__tests__/resolving-scopes.js
+++ b/reference-implementation/__tests__/resolving-scopes.js
@@ -1,0 +1,79 @@
+'use strict';
+const { URL } = require('url');
+const { parseFromString } = require('../lib/parser.js');
+const { resolve } = require('../lib/resolver.js');
+
+const mapBaseURL = new URL('https://example.com/app/index.html');
+const scriptURL = new URL('https://example.com/js/app.mjs');
+
+function makeResolveUnderTest(mapString) {
+  const map = parseFromString(mapString, mapBaseURL);
+  return (specifier, baseURL = scriptURL) => resolve(specifier, map, baseURL);
+}
+
+describe('Mapped using scope instead of "imports"', () => {
+  it('should fail when the mapping is to an empty array', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "scopes": {
+        "/js": {
+          "moment": null,
+          "lodash": []
+        }
+      }
+    }`);
+
+    expect(() => resolveUnderTest('moment')).toThrow(TypeError);
+    expect(() => resolveUnderTest('lodash')).toThrow(TypeError);
+  });
+
+  describe('Package-like scenarios', () => {
+    const resolveUnderTest = makeResolveUnderTest(`{
+      "imports": {
+        "moment": "/node_modules/moment/src/moment.js",
+        "moment/": "/node_modules/moment/src/",
+        "lodash-dot": "./node_modules/lodash-es/lodash.js",
+        "lodash-dot/": "./node_modules/lodash-es/",
+        "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
+        "lodash-dotdot/": "../node_modules/lodash-es/"
+      },
+      "scopes": {
+        "/": {
+          "moment": "/node_modules_3/moment/src/moment.js"
+        },
+        "/js": {
+          "lodash-dot": "./node_modules_2/lodash-es/lodash.js",
+          "lodash-dot/": "./node_modules_2/lodash-es/",
+          "lodash-dotdot": "../node_modules_2/lodash-es/lodash.js",
+          "lodash-dotdot/": "../node_modules_2/lodash-es/"
+        }
+      }
+    }`);
+
+    const subScriptURL = new URL('https://example.com/app.mjs');
+
+    it('should resolve scoped and not cascade', () => {
+      expect(resolveUnderTest('lodash-dot')).toMatchURL('https://example.com/app/node_modules_2/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dotdot')).toMatchURL('https://example.com/node_modules_2/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dot/foo')).toMatchURL('https://example.com/app/node_modules_2/lodash-es/foo');
+      expect(resolveUnderTest('lodash-dotdot/foo')).toMatchURL('https://example.com/node_modules_2/lodash-es/foo');
+    });
+
+    it('should apply best scope match', () => {
+      expect(resolveUnderTest('moment', subScriptURL)).toMatchURL('https://example.com/node_modules_3/moment/src/moment.js');
+    });
+
+    it('should fallback to imports', () => {
+      expect(resolveUnderTest('moment/foo', subScriptURL)).toMatchURL('https://example.com/node_modules/moment/src/foo');
+      expect(resolveUnderTest('lodash-dot', subScriptURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dotdot', subScriptURL)).toMatchURL('https://example.com/node_modules/lodash-es/lodash.js');
+      expect(resolveUnderTest('lodash-dot/foo', subScriptURL)).toMatchURL('https://example.com/app/node_modules/lodash-es/foo');
+      expect(resolveUnderTest('lodash-dotdot/foo', subScriptURL)).toMatchURL('https://example.com/node_modules/lodash-es/foo');
+    });
+
+    it('should still fail for package modules that are not declared', () => {
+      expect(() => resolveUnderTest('underscore/')).toThrow(TypeError);
+      expect(() => resolveUnderTest('underscore/foo')).toThrow(TypeError);
+    });
+  });
+});
+

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -8,45 +8,20 @@ exports.parseFromString = (input, baseURL) => {
     throw new TypeError('Import map JSON must be an object.');
   }
 
-  if ('imports' in parsed && !isJSONObject(parsed.imports)) {
-    throw new TypeError('Import map\'s imports value must be an object.');
-  }
-
-  if ('scopes' in parsed && !isJSONObject(parsed.scopes)) {
-    throw new TypeError('Import map\'s scopes value must be an object.');
-  }
-
   let sortedAndNormalizedImports = {};
   if ('imports' in parsed) {
-    sortedAndNormalizedImports = normalizeSpecifierMap(parsed.imports, baseURL);
-  }
-
-  const normalizedScopes = {};
-  if ('scopes' in parsed) {
-    for (const [scopePrefix, specifierMap] of Object.entries(parsed.scopes)) {
-      if (!isJSONObject(specifierMap)) {
-        throw new TypeError(`The value for the "${scopePrefix}" scope prefix must be an object.`);
-      }
-
-      const scopePrefixURL = tryURLParse(scopePrefix, baseURL);
-      if (scopePrefixURL === null) {
-        continue;
-      }
-
-      if (!hasFetchScheme(scopePrefixURL)) {
-        console.warn(`Invalid scope "${scopePrefixURL}". Scope URLs must have a fetch scheme.`);
-        continue;
-      }
-
-      const normalizedScopePrefix = scopePrefixURL.href;
-      normalizedScopes[normalizedScopePrefix] = normalizeSpecifierMap(specifierMap, baseURL);
+    if (!isJSONObject(parsed.imports)) {
+      throw new TypeError('Import map\'s imports value must be an object.');
     }
+    sortedAndNormalizedImports = sortAndNormalizeSpecifierMap(parsed.imports, baseURL);
   }
 
-  const sortedAndNormalizedScopes = {};
-  const sortedScopeKeys = Object.keys(normalizedScopes).sort(longerLengthThenCodeUnitOrder);
-  for (const key of sortedScopeKeys) {
-    sortedAndNormalizedScopes[key] = normalizedScopes[key];
+  let sortedAndNormalizedScopes = {};
+  if ('scopes' in parsed) {
+    if (!isJSONObject(parsed.scopes)) {
+      throw new TypeError('Import map\'s scopes value must be an object.');
+    }
+    sortedAndNormalizedScopes = sortAndNormalizeScopes(parsed.scopes, baseURL);
   }
 
   // Always have these two keys, and exactly these two keys, in the result.
@@ -56,9 +31,9 @@ exports.parseFromString = (input, baseURL) => {
   };
 };
 
-function normalizeSpecifierMap(obj, baseURL) {
+function sortAndNormalizeSpecifierMap(obj, baseURL) {
   // Normalize all entries into arrays
-  const result = {};
+  const normalized = {};
   for (const [specifierKey, value] of Object.entries(obj)) {
     const normalizedSpecifierKey = normalizeSpecifierKey(specifierKey, baseURL);
     if (normalizedSpecifierKey === null) {
@@ -66,17 +41,17 @@ function normalizeSpecifierMap(obj, baseURL) {
     }
 
     if (typeof value === 'string') {
-      result[normalizedSpecifierKey] = [value];
+      normalized[normalizedSpecifierKey] = [value];
     } else if (value === null) {
-      result[normalizedSpecifierKey] = [];
+      normalized[normalizedSpecifierKey] = [];
     } else if (Array.isArray(value)) {
-      result[normalizedSpecifierKey] = obj[specifierKey];
+      normalized[normalizedSpecifierKey] = obj[specifierKey];
     }
   }
 
   // Normalize/validate each potential address in the array
-  for (const [key, addressArray] of Object.entries(result)) {
-    result[key] = addressArray
+  for (const [key, addressArray] of Object.entries(normalized)) {
+    normalized[key] = addressArray
       .map(address => normalizeAddress(address, baseURL))
       .filter(address => {
         if (address === null) {
@@ -92,9 +67,39 @@ function normalizeSpecifierMap(obj, baseURL) {
   }
 
   const sortedAndNormalized = {};
-  const sortedKeys = Object.keys(result).sort(longerLengthThenCodeUnitOrder);
+  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
   for (const key of sortedKeys) {
-    sortedAndNormalized[key] = result[key];
+    sortedAndNormalized[key] = normalized[key];
+  }
+
+  return sortedAndNormalized;
+}
+
+function sortAndNormalizeScopes(obj, baseURL) {
+  const normalized = {};
+  for (const [scopePrefix, specifierMap] of Object.entries(obj)) {
+    if (!isJSONObject(specifierMap)) {
+      throw new TypeError(`The value for the "${scopePrefix}" scope prefix must be an object.`);
+    }
+
+    const scopePrefixURL = tryURLParse(scopePrefix, baseURL);
+    if (scopePrefixURL === null) {
+      continue;
+    }
+
+    if (!hasFetchScheme(scopePrefixURL)) {
+      console.warn(`Invalid scope "${scopePrefixURL}". Scope URLs must have a fetch scheme.`);
+      continue;
+    }
+
+    const normalizedScopePrefix = scopePrefixURL.href;
+    normalized[normalizedScopePrefix] = sortAndNormalizeSpecifierMap(specifierMap, baseURL);
+  }
+
+  const sortedAndNormalized = {};
+  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedKeys) {
+    sortedAndNormalized[key] = normalized[key];
   }
 
   return sortedAndNormalized;

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -16,15 +16,9 @@ exports.parseFromString = (input, baseURL) => {
     throw new TypeError('Import map\'s scopes value must be an object.');
   }
 
-  let normalizedImports = {};
+  let sortedAndNormalizedImports = {};
   if ('imports' in parsed) {
-    normalizedImports = normalizeSpecifierMap(parsed.imports, baseURL);
-  }
-
-  const sortedAndNormalizedImports = {};
-  const sortedImportsKeys = Object.keys(normalizedImports).sort(longerLengthThenCodeUnitOrder);
-  for (const key of sortedImportsKeys) {
-    sortedAndNormalizedImports[key] = normalizedImports[key];
+    sortedAndNormalizedImports = normalizeSpecifierMap(parsed.imports, baseURL);
   }
 
   const normalizedScopes = {};
@@ -49,10 +43,16 @@ exports.parseFromString = (input, baseURL) => {
     }
   }
 
+  const sortedAndNormalizedScopes = {};
+  const sortedScopeKeys = Object.keys(normalizedScopes).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedScopeKeys) {
+    sortedAndNormalizedScopes[key] = normalizedScopes[key];
+  }
+
   // Always have these two keys, and exactly these two keys, in the result.
   return {
     imports: sortedAndNormalizedImports,
-    scopes: normalizedScopes
+    scopes: sortedAndNormalizedScopes
   };
 };
 
@@ -91,7 +91,13 @@ function normalizeSpecifierMap(obj, baseURL) {
       });
   }
 
-  return result;
+  const sortedAndNormalized = {};
+  const sortedKeys = Object.keys(result).sort(longerLengthThenCodeUnitOrder);
+  for (const key of sortedKeys) {
+    sortedAndNormalized[key] = result[key];
+  }
+
+  return sortedAndNormalized;
 }
 
 function normalizeSpecifierKey(specifierKey, baseURL) {

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -6,13 +6,9 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
   const asURL = tryURLLikeSpecifierParse(specifier, scriptURL);
   const normalizedSpecifier = asURL ? asURL.href : specifier;
 
-  for (const [normalizedScopePrefix, scopeImports] of Object.entries(parsedImportMap.scopes)) {
-    // an alternative to the double '/' check could be to normalize scopes to
-    // never contain a trailing '/' in the parsing phase
-    if (scriptURL.href.startsWith(normalizedScopePrefix) &&
-        (scriptURL.href.length === normalizedScopePrefix.length ||
-         scriptURL.href[normalizedScopePrefix.length] === '/' ||
-         scriptURL.href[normalizedScopePrefix.length - 1] === '/')) {
+  for (const [normalizedScopeKey, scopeImports] of Object.entries(parsedImportMap.scopes)) {
+    if (scriptURL.href === normalizedScopeKey ||
+        (normalizedScopeKey.endsWith('/') && scriptURL.href.startsWith(normalizedScopeKey))) {
       const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, asURL, scopeImports);
       if (scopeImportsMatch) {
         return scopeImportsMatch;

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -6,9 +6,37 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
   const asURL = tryURLLikeSpecifierParse(specifier, scriptURL);
   const normalizedSpecifier = asURL ? asURL.href : specifier;
 
-  // TODO: support scopes!
+  for (const [normalizedScopePrefix, scopeImports] of Object.entries(parsedImportMap.scopes)) {
+    // an alternative to the double '/' check could be to normalize scopes to
+    // never contain a trailing '/' in the parsing phase
+    if (scriptURL.href.startsWith(normalizedScopePrefix) &&
+        (scriptURL.href.length === normalizedScopePrefix.length ||
+         scriptURL.href[normalizedScopePrefix.length] === '/' ||
+         scriptURL.href[normalizedScopePrefix.length - 1] === '/')) {
+      const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, asURL, scopeImports);
+      if (scopeImportsMatch) {
+        return scopeImportsMatch;
+      }
+      // scope match does not cascade
+      break;
+    }
+  }
 
-  for (const [specifierKey, addressArray] of Object.entries(parsedImportMap.imports)) {
+  const importsMatch = resolveImportsMatch(normalizedSpecifier, asURL, parsedImportMap.imports);
+  if (importsMatch) {
+    return importsMatch;
+  }
+
+  // The specifier was able to be turned into a URL, but wasn't remapped into anything.
+  if (asURL) {
+    return asURL;
+  }
+
+  throw new TypeError(`Unmapped bare specifier ${specifier}`);
+};
+
+function resolveImportsMatch(normalizedSpecifier, asURL, importMap) {
+  for (const [specifierKey, addressArray] of Object.entries(importMap)) {
     if (addressArray.length > 1) {
       throw new Error('Not yet implemented');
     }
@@ -26,11 +54,5 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
       return new URL(afterPrefix, address);
     }
   }
-
-  // The specifier was able to be turned into a URL, but wasn't remapped into anything.
-  if (asURL) {
-    return asURL;
-  }
-
-  throw new TypeError(`Unmapped bare specifier ${specifier}`);
-};
+  return undefined;
+}

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -13,8 +13,6 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
       if (scopeImportsMatch) {
         return scopeImportsMatch;
       }
-      // scope match does not cascade
-      break;
     }
   }
 


### PR DESCRIPTION
This provides a simple implementation of scoped resolution with the various fallback tests.

The gist of the approach is:
* Sort scopes, and scope imports just like imports
* Generalize the matcher into a `resolveImportsMatch` function which is used on scopes
* The first best matching scope is checked for import resolution, falling back to the global imports.

Because of the way scopes are normalized during parsing, we end up needing to check for `parentURL[normalizedScopeURL.length] === '/' || parntURL[normalizedScopeURL.length - 1] === '/'` because scopes may or may not end in '/'. One optimization here might be to normalize scopes to always be with or without the trailing slash (possibly without?), but that seemed to affect quite a few of the parsing tests when I tried it. I could certainly implement that as well though.

Any other thoughts re edge cases very welcome, but I think most are already covered by the base import maps themselves.