### PR TITLE
Allow URL-like specifiers keys to be prefix-mapped too

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,19 @@ This remapping ensures that any imports of the unpkg.com version of Vue (at leas
 
 This remapping ensures that any URL-like imports that resolve to `/app/helpers.mjs`, including e.g. an `import "./helpers.mjs"` from files inside `/app/`, or an `import "../helpers.mjs"` from files inside `/app/models`, will instead resolve to `/app/helpers/index.mjs`. This is probably not a good idea; instead of creating an indirection which obfuscates your code, you should instead just update your source files to import the correct files. But, it is a useful example for demonstrating the capabilities of import maps.
 
-The point is that the remapping works the same for URL-like imports as for bare imports. Our previous examples changed the resolution of specifiers like `"lodash"`, and thus changed the meaning of `import "lodash"`. Here we're changing the resolution of specifiers like `"/app/helpers.mjs"`, and thus changing the meaning of `import "/app/helpers.mjs"`.
+Such remapping can also be done on a prefix-matched basis, by ending the specifier key with a trailing slash:
+
+```json
+{
+  "imports": {
+    "https://www.unpkg.com/vue/": "/node_modules/vue/"
+  }
+}
+```
+
+This version ensures that import statements for specifiers that start with the substring `"https://www.unpkg.com/vue/"` will be mapped to the corresponding URL underneath `/node_modules/vue/`.
+
+In general, the point is that the remapping works the same for URL-like imports as for bare imports. Our previous examples changed the resolution of specifiers like `"lodash"`, and thus changed the meaning of `import "lodash"`. Here we're changing the resolution of specifiers like `"/app/helpers.mjs"`, and thus changing the meaning of `import "/app/helpers.mjs"`.
 
 #### Extension-less imports
 

--- a/reference-implementation/__tests__/resolving.js
+++ b/reference-implementation/__tests__/resolving.js
@@ -156,6 +156,9 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
         "/": "/lib/slash-only/",
         "./": "/lib/dotslash-only/",
 
+        "/test/": "/lib/url-trailing-slash/",
+        "./test/": "/lib/url-trailing-slash-dot/",
+
         "/test": "/lib/test1.mjs",
         "../test": "/lib/test2.mjs"
       }
@@ -197,6 +200,11 @@ describe('Mapped using the "imports" key only (no scopes)', () => {
       expect(resolveUnderTest('https://example.com/app/')).toMatchURL('https://example.com/lib/dotslash-only/');
       expect(resolveUnderTest('/app/')).toMatchURL('https://example.com/lib/dotslash-only/');
       expect(resolveUnderTest('../app/')).toMatchURL('https://example.com/lib/dotslash-only/');
+    });
+
+    it('should remap URLs that are prefix-matched by keys with trailing slashes', () => {
+      expect(resolveUnderTest('/test/foo.mjs')).toMatchURL('https://example.com/lib/url-trailing-slash/foo.mjs');
+      expect(resolveUnderTest('https://example.com/app/test/foo.mjs')).toMatchURL('https://example.com/lib/url-trailing-slash-dot/foo.mjs');
     });
 
     it('should use the last entry\'s address when URL-like specifiers parse to the same absolute URL', () => {

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -9,14 +9,14 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
   for (const [normalizedScopeKey, scopeImports] of Object.entries(parsedImportMap.scopes)) {
     if (scriptURL.href === normalizedScopeKey ||
         (normalizedScopeKey.endsWith('/') && scriptURL.href.startsWith(normalizedScopeKey))) {
-      const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, asURL, scopeImports);
+      const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, scopeImports);
       if (scopeImportsMatch) {
         return scopeImportsMatch;
       }
     }
   }
 
-  const importsMatch = resolveImportsMatch(normalizedSpecifier, asURL, parsedImportMap.imports);
+  const importsMatch = resolveImportsMatch(normalizedSpecifier, parsedImportMap.imports);
   if (importsMatch) {
     return importsMatch;
   }
@@ -29,7 +29,7 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
   throw new TypeError(`Unmapped bare specifier ${specifier}`);
 };
 
-function resolveImportsMatch(normalizedSpecifier, asURL, importMap) {
+function resolveImportsMatch(normalizedSpecifier, importMap) {
   for (const [specifierKey, addressArray] of Object.entries(importMap)) {
     if (addressArray.length > 1) {
       throw new Error('Not yet implemented');
@@ -43,7 +43,7 @@ function resolveImportsMatch(normalizedSpecifier, asURL, importMap) {
       return address;
     }
 
-    if (asURL === null && specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+    if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
       const afterPrefix = normalizedSpecifier.substring(specifierKey.length);
       return new URL(afterPrefix, address);
     }


### PR DESCRIPTION
Closes #91.

@guybedford if you have time to review over the next day or two that'd be lovely, but it's fine if not!

My favorite part is how the actual change involved removing a special-case in the resolver code.