### PR TITLE
Link mime-type notes to issue 105 (re CSP)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -23,7 +23,7 @@ If a `<script type="importmap">` is encountered when _acquiring import maps_ is 
 Encountering a `<script type="importmap">` while _acquiring import maps_ is true will kick off a procedure roughly like this:
 
 1. If it's an external script (i.e. has a `src=""`), fetch it, using the usual "good defaults" of `<script type="module">`. (E.g., always UTF-8, "cors" mode, MIME type must match, ...)
-   - What should be the MIME type? Let's say `application/json+importmap`.
+   - What should be the MIME type? Let's say `application/importmap+json`.
      The required mime type should be distinct so that pre-existing services that assume `application/json`
      for uploaded content, and web services that might unintentionally produce something that looks like an
      importmap do not [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).

--- a/spec.md
+++ b/spec.md
@@ -23,7 +23,10 @@ If a `<script type="importmap">` is encountered when _acquiring import maps_ is 
 Encountering a `<script type="importmap">` while _acquiring import maps_ is true will kick off a procedure roughly like this:
 
 1. If it's an external script (i.e. has a `src=""`), fetch it, using the usual "good defaults" of `<script type="module">`. (E.g., always UTF-8, "cors" mode, MIME type must match, ...)
-  - What should be the MIME type? Let's say `application/json+importmap`? Maybe accept any JSON MIME type.
+   - What should be the MIME type? Let's say `application/json+importmap`.
+     The required mime type should be distinct so that pre-existing services that assume `application/json`
+     for uploaded content, and web services that might unintentionally produce something that looks like an
+     importmap do not [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).
 1. Parse the result as JSON into a spec-level struct (see below). (Will need to solve [whatwg/infra#159](https://github.com/whatwg/infra/issues/159) as part of this.)
 1. Merge the resulting struct into our realm's **merged import map** (see below).
 


### PR DESCRIPTION
This incorporates the conclusion at the end of https://github.com/WICG/import-maps/issues/105#issuecomment-475330548

> We should probably not accept any JSON MIME type.

based on the assumptions made by existing hosting providers and JSON-producing web services as to what can be safely hosted on origins that appear on CSP source white lists.