### PR TITLE
Fix minor error handling issues around specifier resolution

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -176,7 +176,11 @@ At some point, each [=environment settings object=] will get an <dfn for="enviro
 <div algorithm>
   To <dfn lt="parse a URL-like import specifier|parsing a URL-like import specifier">parse a URL-like import specifier</dfn>, given a [=string=] |specifier| and a [=URL=] |baseURL|:
 
-  1. If |specifier| [=/starts with=] "`/`", "`./`", or "`../`", then return the result of [=URL parser|parsing=] |specifier| with |baseURL| as the base URL.
+  1. If |specifier| [=/starts with=] "`/`", "`./`", or "`../`", then:
+    1. Let |url| be the result of [=URL parser|parsing=] |specifier| with |baseURL| as the base URL.
+    1. If |url| is failure, then return null.
+       <p class="note">For example, |specifier| is "`../foo`" and |baseURL| is a data: URL here.</p>
+    1. Return |url|.
   1. Let |url| be the result of [=URL parser|parsing=] |specifier| (with no base URL).
   1. If |url| is failure, then return null.
   1. If |url|'s [=url/scheme=] is either a [=fetch scheme=] or "`std`", then return |url|.
@@ -208,7 +212,7 @@ At some point, each [=environment settings object=] will get an <dfn for="enviro
     If |asURL| is not null, then:
     1. If |asURL|'s [=url/scheme=] is "`std`", and |moduleMap|[|asURL|] does not [=map/exist=], then throw a {{TypeError}} indicating that the requested built-in module is not implemented.
     1. Return |asURL|.
-  1. Throw a {{TypeError}} indicating that |specifier| was a bare specifier, but was not remapped to anything by |importMap|.
+  1. Return failure.
 </div>
 
 <p class="advisement">It seems possible that the return type could end up being a [=list=] of [=URLs=], not just a single URL, to support HTTPS → HTTPS fallback. But, we haven't gotten that far yet; for now let's assume it stays a single URL.</p>

--- a/spec.bs
+++ b/spec.bs
@@ -212,14 +212,14 @@ At some point, each [=environment settings object=] will get an <dfn for="enviro
     If |asURL| is not null, then:
     1. If |asURL|'s [=url/scheme=] is "`std`", and |moduleMap|[|asURL|] does not [=map/exist=], then throw a {{TypeError}} indicating that the requested built-in module is not implemented.
     1. Return |asURL|.
-  1. Return failure.
+  1. Throw a {{TypeError}} indicating that |specifier| was a bare specifier, but was not remapped to anything by |importMap|.
 </div>
 
 <p class="advisement">It seems possible that the return type could end up being a [=list=] of [=URLs=], not just a single URL, to support HTTPS → HTTPS fallback. But, we haven't gotten that far yet; for now let's assume it stays a single URL.</p>
 
 All call sites of HTML's existing <a spec="html">resolve a module specifier</a> will need to be updated to pass the appropriate [=script=], not just its [=script/base URL=].
 
-They will also need to be updated to account for it now throwing exceptions, instead of returning failure. (Previously they just turned failures into {{TypeError}}s manually, so this is straightforward.)
+They will also need to be updated to account for it now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
 <div algorithm>
   To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier|, a [=specifier map=] |specifierMap|, and a [=module map=] |moduleMap|:

--- a/spec.bs
+++ b/spec.bs
@@ -179,7 +179,7 @@ At some point, each [=environment settings object=] will get an <dfn for="enviro
   1. If |specifier| [=/starts with=] "`/`", "`./`", or "`../`", then:
     1. Let |url| be the result of [=URL parser|parsing=] |specifier| with |baseURL| as the base URL.
     1. If |url| is failure, then return null.
-       <p class="note">For example, |specifier| is "`../foo`" and |baseURL| is a data: URL here.</p>
+       <p class="example" id="example-bad-urllike-import-specifier">One way this could happen is if |specifier| is "`../foo`" and |baseURL| is a `data:` URL.</p>
     1. Return |url|.
   1. Let |url| be the result of [=URL parser|parsing=] |specifier| (with no base URL).
   1. If |url| is failure, then return null.


### PR DESCRIPTION
- Stop returning failure (instead of null) from
  `parse a URL-like import specifier`.
- Stop throwing inside `resolve a module specifier algorithm`, and
  return failure instead.
  Throwing an error causes e.g. throwing an error in WorkerGlobalScope
  that is not yet ready to execute scripts (
  https://html.spec.whatwg.org/C/#concept-environment-execution-ready-flag
  is false) when it occurred during `fetch a module worker script graph`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/140.html" title="Last updated on Jun 25, 2019, 8:21 AM UTC (1ade17e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/140/cbd5e7d...hiroshige-g:1ade17e.html" title="Last updated on Jun 25, 2019, 8:21 AM UTC (1ade17e)">Diff</a>