### PR TITLE
Update the README and spec.md for recent spec work

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ You can install an import map for your application using a `<script>` element, e
 <script type="importmap" src="import-map.importmap"></script>
 ```
 
-When the `src=""` attribute is used, the resulting HTTP response must have the MIME type `application/importmap+json`. (Why not reuse `application/json`? Doing so could [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).)
+When the `src=""` attribute is used, the resulting HTTP response must have the MIME type `application/importmap+json`. (Why not reuse `application/json`? Doing so could [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).) Like module scripts, the request is made with CORS enabled, and the response is always interpreted as UTF-8.
 
 Because they affect all imports, any import maps must be present and successfully fetched before any module resolution is done. This means that module graph fetching, or any fetching of `import:` URLs, is blocked on import map fetching.
 

--- a/README.md
+++ b/README.md
@@ -662,8 +662,6 @@ _Previous versions of this proposal anticipated making `import:` URLs resolve re
 
 ### Installation
 
-_The below represents a tentative idea. See the issue tracker for more discussion and alternatives: [#1](https://github.com/WICG/import-maps/issues/1)._
-
 You can install an import map for your application using a `<script>` element, either inline (for best performance) or with a `src=""` attribute (in which case you'd better be using HTTP/2 push to get that thing to us as soon as possible):
 
 ```html
@@ -676,12 +674,14 @@ You can install an import map for your application using a `<script>` element, e
 ```
 
 ```html
-<script type="importmap" src="import-map.json"></script>
+<script type="importmap" src="import-map.importmap"></script>
 ```
+
+External import maps must use the MIME type `application/importmap+json`. (Why not reuse `application/json`? Doing so could [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).)
 
 Because they affect all imports, any import maps must be present and successfully fetched before any module resolution is done. This means that module graph fetching, or any fetching of `import:` URLs, is blocked on import map fetching.
 
-Similarly, attempting to add a new `<script type="importmap">` after any module graph fetching, or fetching of `import:` URLs, has started, is an error. The import map will be ignored, and the `<script>` element will fire an error.
+Similarly, attempting to add a new `<script type="importmap">` after any module graph fetching, or fetching of `import:` URLs, has started, is an error. The import map will be ignored, and the `<script>` element will fire an `error` event.
 
 Multiple `<script type="importmap">`s are allowed on the page. (See previous discussion in [#14](https://github.com/WICG/import-maps/issues/14).) They are merged by an intentionally-simple procedure, roughly equivalent to the JavaScript code
 

--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ You can install an import map for your application using a `<script>` element, e
 <script type="importmap" src="import-map.importmap"></script>
 ```
 
-External import maps must use the MIME type `application/importmap+json`. (Why not reuse `application/json`? Doing so could [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).)
+When the `src=""` attribute is used, the resulting HTTP response must have the MIME type `application/importmap+json`. (Why not reuse `application/json`? Doing so could [enable CSP bypasses](https://github.com/WICG/import-maps/issues/105).)
 
 Because they affect all imports, any import maps must be present and successfully fetched before any module resolution is done. This means that module graph fetching, or any fetching of `import:` URLs, is blocked on import map fetching.
 

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# Import maps stuff to formalize and merge into the spec
+# Import semantics yet to be specified
 
 The spec for import maps is located at https://wicg.github.io/import-maps/. This document contains notes on things that will eventually be formalized and make their way into the spec.
 

--- a/spec.md
+++ b/spec.md
@@ -1,35 +1,8 @@
-# Import maps proto-spec
+# Import maps stuff to formalize and merge into the spec
 
-_Note: we also have a slightly-less-proto spec at https://wicg.github.io/import-maps/. We're sorry that it's confusing to have two spec-like documents; we'll merge the contents of this one into that location soon. At this point in time, that one is more rigorous but covers less behavior._
+The spec for import maps is located at https://wicg.github.io/import-maps/. This document contains notes on things that will eventually be formalized and make their way into the spec.
 
-## Installation
-
-### When import maps can be encountered
-
-Each realm (environment settings object) has a boolean, **acquiring import maps**. It is initially true.
-
-The [internal module script graph fetching procedure](https://html.spec.whatwg.org/multipage/webappapis.html#internal-module-script-graph-fetching-procedure) flips the boolean to false. Practically speaking, this happens when:
-
-- Any `<script type="module">` element is connected to the document
-- Any `import()` call is made
-- Any worker module is created, e.g. via `new Worker(url, { type: "module" })`
-
-Additionally, fetching any `import:` URLs will flip this boolean to false. (See below.)
-
-If a `<script type="importmap">` is encountered when _acquiring import maps_ is false, then the developer has made an error. We will signal this by firing an `error` event on the `<script type="importmap">` element, and implementations should also display the error in the developer console.
-
-### Acquiring import maps
-
-Encountering a `<script type="importmap">` while _acquiring import maps_ is true will kick off a procedure roughly like this:
-
-1. If it's an external script (i.e. has a `src=""`), fetch it, using the usual "good defaults" of `<script type="module">`. (E.g., always UTF-8, "cors" mode, MIME type must match, ...)
-  - What should be the MIME type? Let's say `application/json+importmap`? Maybe accept any JSON MIME type.
-1. Parse the result as JSON into a spec-level struct (see below). (Will need to solve [whatwg/infra#159](https://github.com/whatwg/infra/issues/159) as part of this.)
-1. Merge the resulting struct into our realm's **merged import map** (see below).
-
-Any **ongoing fetches of import maps** are noted, while ongoing, so that `import:` URL fetching can block on them (see below).
-
-### Merging import maps
+## Merging import maps
 
 We're looking to do the minimal thing that could work here. As such, I propose the following:
 
@@ -61,29 +34,25 @@ Example:
 
 Note that we do not introspect the scopes. If there's two conflicting definitions of how things behave inside a scope, then the last one wins.
 
-## Resolution
-
-The new "resolve a module specifier" algorithm is prototyped in the [reference implementation](https://github.com/WICG/import-maps/tree/master/reference-implementation). It takes as input a specifier, a parsed import map, and a script URL that the specifier is being resolved in the context of.
-
-For now we will only handle cases where there is at most one fetch-scheme URL in the address array. Cases involving multiple such URLs (such as the [fallbacks for user-supplied packages](./README.md#for-user-supplied-packages) example) require more thought on how to thread through the spec. This corresponds to working through all but the last bullet in the README's section on [further implementation staging](./README.md#further-implementation-staging)
-
 ## `import:` URL fetches
 
-_Unlike previous versions of the proto-spec, `import:` URLs no longer involve changes to the URL parser._
+_Unlike in previous import map proposals, `import:` URLs no longer involve changes to the URL parser._
+
+Fetching an `import:` URL is like fetching a module in that it flips the [acquiring import maps](https://wicg.github.io/import-maps/#environment-settings-object-acquiring-import-maps) boolean to false.
 
 We treat `import:` URLs like `blob:` URLs, in that they get a special entry in [scheme fetch](https://fetch.spec.whatwg.org/#scheme-fetch). Roughly it would do this:
 
-1. Wait for any _ongoing fetches of import maps_.
+1. [Wait for import maps](https://wicg.github.io/import-maps/#wait-for-import-maps).
 1. Let _url_ be _request_'s current URL.
 1. Let _baseURL_ be _request_'s referrer, post-processed to convert "client" into the actual client URL.
 1. Let _specifier_ be _url_'s path.
-1. Let _underlyingURL_ be the result of "resolve a module specifier" given _baseURL_ and _specifier_.
+1. Let _underlyingURL_ be the result of [resolve a module specifier](https://wicg.github.io/import-maps/#resolve-a-module-specifier) given _baseURL_ and _specifier_.
 1. "Do a request to _underlyingURL_". Details unclear; things to consider:
     - Should we just change _request_'s current URL?
     - Should we make this behave like a redirect of some sort?
     - Should we mandate all `import:`-based requests use CORS/etc.? In that case we'd probably recreate a request from scratch.
     - Should we restrict to GETs like `blob:` does?
 
-## TODO: multiple fetch-scheme URL fallbacks
+## Multiple fetch-scheme URL fallbacks
 
-Not sure yet how to handle this. Current thinking is maybe in those cases "resolve a module specifier" returns a list of URLs, but threading that through is hard.
+Not sure yet how to handle this. Current thinking is maybe in those cases [resolve a module specifier](https://wicg.github.io/import-maps/#resolve-a-module-specifier) returns a list of URLs, but threading that through is hard.


### PR DESCRIPTION
Now that the actual specification (spec.bs) has become more solid, we can clean up some tentative notes, and delete most of spec.md.

Closes #119 by including the appropriate explanatory text in the README, instead of in spec.md.