### PR TITLE
Add access check of module URLs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -396,12 +396,16 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
   1. [=map/For each=] |scopePrefix| → |scopeImports| of |importMap|'s [=import map/scopes=],
     1. If |scopePrefix| is |baseURLString|, or if |scopePrefix| ends with U+002F (/) and |baseURLString| [=/starts with=] |scopePrefix|, then:
       1. Let |scopeImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier|, |scopeImports|, and |moduleMap|.
-      1. If |scopeImportsMatch| is not null, then return |scopeImportsMatch|.
+      1. If |scopeImportsMatch| is not null, then:
+        1. [=Check access=] given |scopeImportsMatch|, |settingsObject|, and |baseURL|.
+        1. Return |scopeImportsMatch|.
   1. Let |topLevelImportsMatch| be the reuslt of [=resolving an imports match=] given |normalizedSpecifier|, |importMap|'s [=import map/imports=], and |moduleMap|.
-  1. If |topLevelImportsMatch| is not null, then return |topLevelImportsMatch|.
+  1. If |topLevelImportsMatch| is not null, then:
+    1. [=/Check access=] given |topLevelImportsMatch|, |settingsObject|, and |baseURL|.
+    1. Return |topLevelImportsMatch|.
   1. <p class="note">At this point, the specifier was able to be turned in to a URL, but it wasn't remapped to anything by |importMap|.</p>
     If |asURL| is not null, then:
-    1. If |asURL|'s [=url/scheme=] is "`std`", and |moduleMap|[|asURL|] does not [=map/exist=], then throw a {{TypeError}} indicating that the requested built-in module is not implemented.
+    1. [=/Check access=] given |asURL|, |settingsObject|, and |baseURL|.
     1. Return |asURL|.
   1. Throw a {{TypeError}} indicating that |specifier| was a bare specifier, but was not remapped to anything by |importMap|.
 </div>
@@ -431,6 +435,22 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
       1. Otherwise, <span class="advisement">we have no specification for more complicated fallbacks yet; throw a {{TypeError}} indicating this is not yet supported</span>.
   1. Return null.
 </div>
+<div algorithm>
+  To <dfn>check access</dfn>, given a [=URL=] |url|, an [=environment settings object=] |settings object|, and a [=URL=] |base URL|:
+
+  1. <div class="note">Optionally, we can apply context-dependent access restrictions based on |base URL|. For example, Chromium might implement the followings, which aren't observable by users.
+         1. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return. This allows the use of "`std-internal`" within built-in modules, and rejects "`std-internal`" from user-provided scripts.
+         1. If |url|'s [=url/scheme=] is "`std`", |url| represents an access-restricted built-in module, and |base URL|'s [=url/scheme=] is not "`std-internal`", then throw a {{TypeError}}. This will be used to restrict access to getOriginals only within built-in modules.
+       This kind of access restrictions is similar to import map's scope matching, as both uses the same |base URL|, but the check here is enforced in all cases (and thus can be used as a security mechanism), while import map's scoping can be bypassed as e.g. the URLs in `<script src="..." type="module">` isn't controlled by import maps.
+     </div>
+  1. If |url|'s [=url/scheme=] is "`std`", then:
+    1. If the [=URL serializer|serialization=] of |url| contains U+002F (/), then throw a {{TypeError}} indicating that |url| is a malformed built-in URL.
+    1. Let |moduleMap| be |settings object|'s [=environment settings object/module map=].
+    1. If |moduleMap|[|url|] does not [=map/exist=], then throw a {{TypeError}} indicating that the requested built-in module is not implemented.
+       <p class="note">This condition is added to ensure that |moduleMap|[|url|] does not [=map/exist=] for unimplemented built-ins. Without this condition, <a spec="html">fetch a single module script</a> might be called and |moduleMap|[|url|] can be set to null, which might complicates the spec around built-ins.</p>
+    1. Return.
+  1. If |url|'s [=url/scheme=] is not a [=fetch scheme=], then throw a {{TypeError}} indicating that |url| is not a fetch scheme.
+</div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>
 
@@ -440,3 +460,17 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 * [=Fetch an import() module script graph=] will also need to take a [=script=] instead of a base URL.
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
+
+In addition to the call sites for [=check access=] explicitly added within this spec, insert the following:
+
+<div algorithm="check-access-snippet">
+  1. [=Check access=] given <var ignore>url</var>, |settings object|, and |settings object|'s [=environment settings object/API base URL=]. If this throws an error, then asynchronously complete this algorithm with null, and abort these steps.
+</div>
+
+at the beginning of the following HTML spec concepts (after [=wait for import maps=]):
+
+- [=fetch an external module script graph=]
+- [=fetch a modulepreload module script graph=]
+- [=fetch a module worker script graph=] (using <var ignore>module map settings object</var>)
+
+<p class="note">[=Check access=] is applied to all module URLs before start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>

--- a/spec.bs
+++ b/spec.bs
@@ -397,11 +397,11 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
     1. If |scopePrefix| is |baseURLString|, or if |scopePrefix| ends with U+002F (/) and |baseURLString| [=/starts with=] |scopePrefix|, then:
       1. Let |scopeImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier|, |scopeImports|, and |moduleMap|.
       1. If |scopeImportsMatch| is not null, then:
-        1. [=Validate the module script URL=] given |scopeImportsMatch|, |settingsObject|, and |baseURL|.
+        1. [=Validate the module script URL=] given |scopeImportsMatch|, |settingsObject|, and |baseURL|. <!-- TODO: when we simplify/centralize validation checks, remove this check. It can never fail. -->
         1. Return |scopeImportsMatch|.
   1. Let |topLevelImportsMatch| be the reuslt of [=resolving an imports match=] given |normalizedSpecifier|, |importMap|'s [=import map/imports=], and |moduleMap|.
   1. If |topLevelImportsMatch| is not null, then:
-    1. [=Validate the module script URL=] given |topLevelImportsMatch|, |settingsObject|, and |baseURL|.
+    1. [=Validate the module script URL=] given |topLevelImportsMatch|, |settingsObject|, and |baseURL|. <!-- TODO: when we simplify/centralize validation checks, remove this check. It can never fail. -->
     1. Return |topLevelImportsMatch|.
   1. <p class="note">At this point, the specifier was able to be turned in to a URL, but it wasn't remapped to anything by |importMap|.</p>
     If |asURL| is not null, then:
@@ -439,10 +439,6 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
 <div algorithm>
   To <dfn lt="validate the module script URL|validate a module script URL">validate a module script URL</dfn>, given a [=URL=] |url|, an [=environment settings object=] |settings object|, and a [=URL=] |base URL|:
 
-  1. <div class="note">Optionally, we can apply context-dependent access restrictions based on |base URL|. For example, Chromium might implement the following, which isn't observable by users.
-         1. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return. This hides internal built-in modules from user-provided scripts.
-       This kind of access restrictions is similar to import map's scope matching, as both uses the same |base URL|, but the check here is enforced in all cases (and thus can be used as a security mechanism), while import map's scoping can be bypassed as e.g. the URLs in `<script src="..." type="module">` isn't controlled by import maps.
-     </div>
   1. If |url|'s [=url/scheme=] is "`std`", then:
     1. If the [=URL serializer|serialization=] of |url| contains U+002F (/), then throw a {{TypeError}} indicating that |url| is a malformed built-in URL.
     1. Let |moduleMap| be |settings object|'s [=environment settings object/module map=].
@@ -450,6 +446,16 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
        <p class="note">This condition is added to ensure that |moduleMap|[|url|] does not [=map/exist=] for unimplemented built-ins. Without this condition, <a spec="html">fetch a single module script</a> might be called and |moduleMap|[|url|] can be set to null, which might complicates the spec around built-ins.</p>
     1. Return.
   1. If |url|'s [=url/scheme=] is not a [=fetch scheme=], then throw a {{TypeError}} indicating that |url| is not a fetch scheme.
+
+  <div class="note">
+    This algorithm provides a convenient place for implementations to insert other useful behaviors, as long as they are not observable to web content. For example, Chromium might insert the following step at the beginning of the algorithm:
+
+    0. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return.
+
+    This introduces a type of internal built-in module that is only accessible to other internal built-in modules. Similar steps could be used to, for example, change how extension scripts access modules.
+
+    Since [=validate a module script URL=] is called before any module script fetches, such checks are reliable and can be used as a security mechanism.
+  </div>
 </div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>
@@ -461,6 +467,8 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
+<hr>
+
 In addition to the call sites for [=validate a module script URL=] explicitly added within this spec, insert the following at the beginning of <a spec="html">fetch a single module script</a>:
 
 <div algorithm="check-access-snippet">
@@ -468,7 +476,7 @@ In addition to the call sites for [=validate a module script URL=] explicitly ad
 </div>
 
 <div class="note">
-This will call [=validate the module script URL=] twice for each non-toplevel script fetch, in [=resolve a module specifier=], then in <a spec="html">fetch a single module script</a>. The behavior of the two calls is identical.
+This will call [=validate the module script URL=] twice for each non-toplevel script fetch, first in [=resolve a module specifier=], and then in <a spec="html">fetch a single module script</a>. The behavior of the two calls is identical.
 
 Alternatively, we can add the snippet at the beginning of the following HTML spec concepts (after [=wait for import maps=]), so that the validation is not done twice:
 
@@ -478,4 +486,4 @@ Alternatively, we can add the snippet at the beginning of the following HTML spe
 
 </div>
 
-<p class="note">[=Validate a module script URL=] is applied to all module URLs before start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>
+<p class="note">[=Validate a module script URL=] is applied to all module URLs before they start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>

--- a/spec.bs
+++ b/spec.bs
@@ -461,16 +461,21 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
-In addition to the call sites for [=validate a module script URL=] explicitly added within this spec, insert the following:
+In addition to the call sites for [=validate a module script URL=] explicitly added within this spec, insert the following at the beginning of <a spec="html">fetch a single module script</a>:
 
 <div algorithm="check-access-snippet">
-  1. [=Validate the module script URL=] given <var ignore>url</var>, |settings object|, and |settings object|'s [=environment settings object/API base URL=]. If this throws an error, then asynchronously complete this algorithm with null, and abort these steps.
+  1. [=Validate the module script URL=] given <var ignore>url</var>, |module map settings object|, and |module map settings object|'s [=environment settings object/API base URL=]. If this throws an error, then asynchronously complete this algorithm with null, and abort these steps.
 </div>
 
-at the beginning of the following HTML spec concepts (after [=wait for import maps=]):
+<div class="note">
+This will call [=validate the module script URL=] twice for each non-toplevel script fetch, in [=resolve a module specifier=], then in <a spec="html">fetch a single module script</a>. The behavior of the two calls is identical.
 
-- [=fetch an external module script graph=]
-- [=fetch a modulepreload module script graph=]
-- [=fetch a module worker script graph=] (using <var ignore>module map settings object</var>)
+Alternatively, we can add the snippet at the beginning of the following HTML spec concepts (after [=wait for import maps=]), so that the validation is not done twice:
+
+- [=fetch an external module script graph=] (using <var ignore>settings object</var>)
+- [=fetch a modulepreload module script graph=] (using <var ignore>settings object</var>)
+- [=fetch a module worker script graph=]
+
+</div>
 
 <p class="note">[=Validate a module script URL=] is applied to all module URLs before start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>

--- a/spec.bs
+++ b/spec.bs
@@ -397,15 +397,15 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
     1. If |scopePrefix| is |baseURLString|, or if |scopePrefix| ends with U+002F (/) and |baseURLString| [=/starts with=] |scopePrefix|, then:
       1. Let |scopeImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier|, |scopeImports|, and |moduleMap|.
       1. If |scopeImportsMatch| is not null, then:
-        1. [=Check access=] given |scopeImportsMatch|, |settingsObject|, and |baseURL|.
+        1. [=Validate the module script URL=] given |scopeImportsMatch|, |settingsObject|, and |baseURL|.
         1. Return |scopeImportsMatch|.
   1. Let |topLevelImportsMatch| be the reuslt of [=resolving an imports match=] given |normalizedSpecifier|, |importMap|'s [=import map/imports=], and |moduleMap|.
   1. If |topLevelImportsMatch| is not null, then:
-    1. [=/Check access=] given |topLevelImportsMatch|, |settingsObject|, and |baseURL|.
+    1. [=Validate the module script URL=] given |topLevelImportsMatch|, |settingsObject|, and |baseURL|.
     1. Return |topLevelImportsMatch|.
   1. <p class="note">At this point, the specifier was able to be turned in to a URL, but it wasn't remapped to anything by |importMap|.</p>
     If |asURL| is not null, then:
-    1. [=/Check access=] given |asURL|, |settingsObject|, and |baseURL|.
+    1. [=Validate the module script URL=] given |asURL|, |settingsObject|, and |baseURL|.
     1. Return |asURL|.
   1. Throw a {{TypeError}} indicating that |specifier| was a bare specifier, but was not remapped to anything by |importMap|.
 </div>
@@ -435,8 +435,9 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
       1. Otherwise, <span class="advisement">we have no specification for more complicated fallbacks yet; throw a {{TypeError}} indicating this is not yet supported</span>.
   1. Return null.
 </div>
+
 <div algorithm>
-  To <dfn>check access</dfn>, given a [=URL=] |url|, an [=environment settings object=] |settings object|, and a [=URL=] |base URL|:
+  To <dfn lt="validate the module script URL|validate a module script URL">validate a module script URL</dfn>, given a [=URL=] |url|, an [=environment settings object=] |settings object|, and a [=URL=] |base URL|:
 
   1. <div class="note">Optionally, we can apply context-dependent access restrictions based on |base URL|. For example, Chromium might implement the followings, which aren't observable by users.
          1. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return. This allows the use of "`std-internal`" within built-in modules, and rejects "`std-internal`" from user-provided scripts.
@@ -461,10 +462,10 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
-In addition to the call sites for [=check access=] explicitly added within this spec, insert the following:
+In addition to the call sites for [=validate a module script URL=] explicitly added within this spec, insert the following:
 
 <div algorithm="check-access-snippet">
-  1. [=Check access=] given <var ignore>url</var>, |settings object|, and |settings object|'s [=environment settings object/API base URL=]. If this throws an error, then asynchronously complete this algorithm with null, and abort these steps.
+  1. [=Validate the module script URL=] given <var ignore>url</var>, |settings object|, and |settings object|'s [=environment settings object/API base URL=]. If this throws an error, then asynchronously complete this algorithm with null, and abort these steps.
 </div>
 
 at the beginning of the following HTML spec concepts (after [=wait for import maps=]):
@@ -473,4 +474,4 @@ at the beginning of the following HTML spec concepts (after [=wait for import ma
 - [=fetch a modulepreload module script graph=]
 - [=fetch a module worker script graph=] (using <var ignore>module map settings object</var>)
 
-<p class="note">[=Check access=] is applied to all module URLs before start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>
+<p class="note">[=Validate a module script URL=] is applied to all module URLs before start loading, even in paths where [=resolve a module specifier=] and import maps are not applied (e.g. `<script src="..." type="module">`).</p>

--- a/spec.bs
+++ b/spec.bs
@@ -439,9 +439,8 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
 <div algorithm>
   To <dfn lt="validate the module script URL|validate a module script URL">validate a module script URL</dfn>, given a [=URL=] |url|, an [=environment settings object=] |settings object|, and a [=URL=] |base URL|:
 
-  1. <div class="note">Optionally, we can apply context-dependent access restrictions based on |base URL|. For example, Chromium might implement the followings, which aren't observable by users.
-         1. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return. This allows the use of "`std-internal`" within built-in modules, and rejects "`std-internal`" from user-provided scripts.
-         1. If |url|'s [=url/scheme=] is "`std`", |url| represents an access-restricted built-in module, and |base URL|'s [=url/scheme=] is not "`std-internal`", then throw a {{TypeError}}. This will be used to restrict access to getOriginals only within built-in modules.
+  1. <div class="note">Optionally, we can apply context-dependent access restrictions based on |base URL|. For example, Chromium might implement the following, which isn't observable by users.
+         1. If |url|'s [=url/scheme=] is "`std-internal`" and |base URL|'s [=url/scheme=] is "`std-internal`", then return. This hides internal built-in modules from user-provided scripts.
        This kind of access restrictions is similar to import map's scope matching, as both uses the same |base URL|, but the check here is enforced in all cases (and thus can be used as a security mechanism), while import map's scoping can be bypassed as e.g. the URLs in `<script src="..." type="module">` isn't controlled by import maps.
      </div>
   1. If |url|'s [=url/scheme=] is "`std`", then:


### PR DESCRIPTION
This commit reject the following URLs as request URLs of module scripts in all cases.

- Non-fetch scheme URLs.
- std: URLs with `/`.
- std: URLs of not implemented built-in modules.

These can't be the output of import maps since before
(i.e. the result of `resolve an imports match`),
but were allowed if directly specified in `<script>` or not mapped by import maps.

This commit also adds a non-normative placeholder for
referringScript-dependent access controls,
which is helpful for Chromium implementation.

This commit also adds support for the case where `referringScript`
is null in `resolve a module specifier`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/152.html" title="Last updated on Jul 12, 2019, 6:30 PM UTC (f930690)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/152/988e9b3...hiroshige-g:f930690.html" title="Last updated on Jul 12, 2019, 6:30 PM UTC (f930690)">Diff</a>