### PR TITLE
Fix forgotten return value for "resolve an imports match"

### DIFF
--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -13,14 +13,14 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
     if (scopePrefix === scriptURLString ||
         (scopePrefix.endsWith('/') && scriptURLString.startsWith(scopePrefix))) {
       const scopeImportsMatch = resolveImportsMatch(normalizedSpecifier, scopeImports);
-      if (scopeImportsMatch) {
+      if (scopeImportsMatch !== null) {
         return scopeImportsMatch;
       }
     }
   }
 
   const topLevelImportsMatch = resolveImportsMatch(normalizedSpecifier, parsedImportMap.imports);
-  if (topLevelImportsMatch) {
+  if (topLevelImportsMatch !== null) {
     return topLevelImportsMatch;
   }
 
@@ -71,5 +71,5 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
       }
     }
   }
-  return undefined;
+  return null;
 }

--- a/spec.bs
+++ b/spec.bs
@@ -429,6 +429,7 @@ To <dfn>register an import map</dfn> given a [=string=] or a null |source text|,
         1. If |url| is failure, throw a {{TypeError}}, implicating |normalizedSpecifier| (and in particular the |afterPrefix| portion).
         1. Return |url|.
       1. Otherwise, <span class="advisement">we have no specification for more complicated fallbacks yet; throw a {{TypeError}} indicating this is not yet supported</span>.
+  1. Return null.
 </div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>


### PR DESCRIPTION
This is what I was referring to at https://github.com/WICG/import-maps/pull/152#issuecomment-510619969. It turns out I was mostly misunderstanding---errors are different from null. But we did have a small spec bug where we never actually returned null.

I'll merge this once CI passes, no need to explicitly review.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/pull/155.html" title="Last updated on Jul 11, 2019, 7:27 PM UTC (c75085d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/155/d18b53d...c75085d.html" title="Last updated on Jul 11, 2019, 7:27 PM UTC (c75085d)">Diff</a>