### PR TITLE
Remove fetch scheme restriction in `parse a URL-like import specifier`

### DIFF
--- a/reference-implementation/__tests__/parsing-addresses.js
+++ b/reference-implementation/__tests__/parsing-addresses.js
@@ -105,14 +105,13 @@ describe('Absolute URL addresses', () => {
         filesystem: expect.toMatchURL('filesystem:good'),
         http: expect.toMatchURL('http://good/'),
         https: expect.toMatchURL('https://good/'),
-        ftp: expect.toMatchURL('ftp://good/')
+        ftp: expect.toMatchURL('ftp://good/'),
+        import: expect.toMatchURL('import:bad'),
+        javascript: expect.toMatchURL('javascript:bad'),
+        mailto: expect.toMatchURL('mailto:bad'),
+        wss: expect.toMatchURL('wss://bad/')
       },
-      [
-        `Invalid address "import:bad" for the specifier key "import".`,
-        `Invalid address "mailto:bad" for the specifier key "mailto".`,
-        `Invalid address "javascript:bad" for the specifier key "javascript".`,
-        `Invalid address "wss:bad" for the specifier key "wss".`
-      ]
+      []
     );
   });
 

--- a/reference-implementation/__tests__/parsing-specifier-keys.js
+++ b/reference-implementation/__tests__/parsing-specifier-keys.js
@@ -76,7 +76,7 @@ describe('Relative URL-like specifier keys', () => {
 });
 
 describe('Absolute URL specifier keys', () => {
-  it('should only accept absolute URL specifier keys with fetch schemes, treating others as bare specifiers', () => {
+  it('Accept all absolute URL specifier keys even with fetch schemes as URLs', () => {
     expectSpecifierMap(
       `{
         "about:good": "/about",
@@ -105,7 +105,7 @@ describe('Absolute URL specifier keys', () => {
         'import:bad': expect.toMatchURL('https://base.example/import'),
         'mailto:bad': expect.toMatchURL('https://base.example/mailto'),
         'javascript:bad': expect.toMatchURL('https://base.example/javascript'),
-        'wss:bad': expect.toMatchURL('https://base.example/wss')
+        'wss://bad/': expect.toMatchURL('https://base.example/wss')
       }
     );
   });

--- a/reference-implementation/__tests__/resolving.js
+++ b/reference-implementation/__tests__/resolving.js
@@ -42,11 +42,11 @@ describe('Unmapped', () => {
     expect(resolveUnderTest('https://///example.com///')).toMatchURL('https://example.com///');
   });
 
-  it('should fail for absolute non-fetch-scheme URLs', () => {
-    expect(() => resolveUnderTest('mailto:bad')).toThrow(TypeError);
-    expect(() => resolveUnderTest('import:bad')).toThrow(TypeError);
-    expect(() => resolveUnderTest('javascript:bad')).toThrow(TypeError);
-    expect(() => resolveUnderTest('wss:bad')).toThrow(TypeError);
+  it('should parse absolute non-fetch-scheme URLs', () => {
+    expect(resolveUnderTest('mailto:bad')).toMatchURL('mailto:bad');
+    expect(resolveUnderTest('import:bad')).toMatchURL('import:bad');
+    expect(resolveUnderTest('javascript:bad')).toMatchURL('javascript:bad');
+    expect(resolveUnderTest('wss:bad')).toMatchURL('wss://bad/');
   });
 
   it('should fail for strings not parseable as absolute URLs and not starting with ./ ../ or /', () => {

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -18,16 +18,7 @@ exports.tryURLLikeSpecifierParse = (specifier, baseURL) => {
   }
 
   const url = exports.tryURLParse(specifier);
-
-  if (url === null) {
-    return null;
-  }
-
-  if (exports.hasFetchScheme(url)) {
-    return url;
-  }
-
-  return null;
+  return url;
 };
 
 exports.hasFetchScheme = url => {

--- a/spec.bs
+++ b/spec.bs
@@ -357,8 +357,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. Return |url|.
   1. Let |url| be the result of [=URL parser|parsing=] |specifier| (with no base URL).
   1. If |url| is failure, then return null.
-  1. If |url|'s [=url/scheme=] is a [=fetch scheme=], then return |url|.
-  1. Return null.
+  1. Return |url|.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This allows non-fetch-scheme URLs as

- import map's keys (as URLs rather than as bare specifiers),
- import map's values, and
- the result of `resolve a module specifier` algorithm.

Fixes #141.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/180.html" title="Last updated on Oct 6, 2019, 8:28 AM UTC (53c0842)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/180/eacf4ea...hiroshige-g:53c0842.html" title="Last updated on Oct 6, 2019, 8:28 AM UTC (53c0842)">Diff</a>