### PR TITLE
Sort keys in the reverse order of `code unit less than`

### DIFF
--- a/reference-implementation/__tests__/parsing-specifier-keys.js
+++ b/reference-implementation/__tests__/parsing-specifier-keys.js
@@ -135,4 +135,30 @@ describe('Absolute URL specifier keys', () => {
       }
     );
   });
+
+  it('should sort correctly (issue #181)', () => {
+    expectSpecifierMap(
+      `{
+        "https://example.com/aaa": "https://example.com/aaa",
+        "https://example.com/a": "https://example.com/a"
+      }`,
+      'https://base.example/',
+      {
+        'https://example.com/aaa': expect.toMatchURL('https://example.com/aaa'),
+        'https://example.com/a': expect.toMatchURL('https://example.com/a')
+      }
+    );
+
+    expectSpecifierMap(
+      `{
+        "https://example.com/a": "https://example.com/a",
+        "https://example.com/aaa": "https://example.com/aaa"
+      }`,
+      'https://base.example/',
+      {
+        'https://example.com/aaa': expect.toMatchURL('https://example.com/aaa'),
+        'https://example.com/a': expect.toMatchURL('https://example.com/a')
+      }
+    );
+  });
 });

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -71,7 +71,7 @@ function sortAndNormalizeSpecifierMap(obj, baseURL) {
   }
 
   const sortedAndNormalized = {};
-  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
+  const sortedKeys = Object.keys(normalized).sort((a, b) => codeUnitCompare(b, a));
   for (const key of sortedKeys) {
     sortedAndNormalized[key] = normalized[key];
   }
@@ -102,7 +102,7 @@ function sortAndNormalizeScopes(obj, baseURL) {
   }
 
   const sortedAndNormalized = {};
-  const sortedKeys = Object.keys(normalized).sort(longerLengthThenCodeUnitOrder);
+  const sortedKeys = Object.keys(normalized).sort((a, b) => codeUnitCompare(b, a));
   for (const key of sortedKeys) {
     sortedAndNormalized[key] = normalized[key];
   }
@@ -129,16 +129,16 @@ function isJSONObject(value) {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function longerLengthThenCodeUnitOrder(a, b) {
-  return compare(b.length, a.length) || compare(a, b);
-}
-
-function compare(a, b) {
+function codeUnitCompare(a, b) {
   if (a > b) {
     return 1;
   }
+
+  /* istanbul ignore else */
   if (b > a) {
     return -1;
   }
-  return 0;
+
+  /* istanbul ignore next */
+  throw new Error('This should never be reached because this is only used on JSON object keys');
 }

--- a/spec.bs
+++ b/spec.bs
@@ -336,7 +336,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
 </div>
 
-<div class="note">We sort keys/scopes in reverse order, to put `"foo/bar/"` before `"foo/"` so that `"foo/bar/"` has a higher priority than `"foo/"`.</div>
+<p class="note">We sort keys/scopes in reverse order, to put `"foo/bar/"` before `"foo/"` so that `"foo/bar/"` has a higher priority than `"foo/"`.</p>
 
 <div algorithm>
   To <dfn lt="normalize a specifier key|normalizing a specifier key">normalize a specifier key</dfn>, given a [=string=] |specifierKey| and a [=URL=] |baseURL|:

--- a/spec.bs
+++ b/spec.bs
@@ -315,7 +315,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
       1. [=Report a warning to the console=] that an invalid address was given for the specifier key |specifierKey|; since |specifierKey| ended in a slash, so must the address.
       1. [=Continue=].
     1. Set |normalized|[|specifierKey|] to |addressURL|.
-  1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |a|'s [=map/key=] is [=longer or code unit less than=] |b|'s [=map/key=].
+  1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
 </div>
 
 <div algorithm>
@@ -333,8 +333,10 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
       1. [=Continue=].
     1. Let |normalizedScopePrefix| be the [=URL serializer|serialization=] of |scopePrefixURL|.
     1. Set |normalized|[|normalizedScopePrefix|] to the result of [=sorting and normalizing a specifier map=] given |potentialSpecifierMap| and |baseURL|.
-  1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |a|'s [=map/key=] is [=longer or code unit less than=] |b|'s [=map/key=].
+  1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
 </div>
+
+<div class="note">We sort keys/scopes in reverse order, to put `"foo/bar/"` before `"foo/"` so that `"foo/bar/"` has a higher priority than `"foo/"`.</div>
 
 <div algorithm>
   To <dfn lt="normalize a specifier key|normalizing a specifier key">normalize a specifier key</dfn>, given a [=string=] |specifierKey| and a [=URL=] |baseURL|:
@@ -359,10 +361,6 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
   1. If |url| is failure, then return null.
   1. If |url|'s [=url/scheme=] is a [=fetch scheme=], then return |url|.
   1. Return null.
-</div>
-
-<div algorithm>
-  A [=string=] |a| is <dfn>longer or code unit less than</dfn> |b| if |a|'s [=string/length=] is greater than |b|'s [=string/length=], or if |a| is [=code unit less than=] |b|.
 </div>
 
 <h2 id="resolving">Resolving module specifiers</h2>


### PR DESCRIPTION
Fixes #181.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/182.html" title="Last updated on Oct 15, 2019, 6:47 AM UTC (cb51eb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/182/eacf4ea...hiroshige-g:cb51eb7.html" title="Last updated on Oct 15, 2019, 6:47 AM UTC (cb51eb7)">Diff</a>