### PR TITLE
Add "security and privacy" section to the spec

### DIFF
--- a/Security and Privacy.md
+++ b/Security and Privacy.md
@@ -1,20 +1,6 @@
 # Security and privacy
 
-## A note on threat models
-
-Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the README's ["Scope" section](./README.md#scope).) Although it may seem that the ability to change how resources are imported from JavaScript is powerful, there is no extra power really granted here. That is, they only change things which the page author could change already, by manually editing their code to use different URLs, or by adding asynchronous try/catch fallback processing.
-
-We do still need to apply the traditional protections against first-party malicious actors, e.g. CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion.) But there is no fundamentally new capability introduced here, that needs new consideration.
-
-## A note on import specifiers
-
-The import specifiers that appear in `import` statements and `import()` expressions are not URLs, and should not be thought of as such.
-
-To date, there has been a [default mechanism](https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier) for translating those strings into URLs. And indeed, some of the strings, such as `"https://example.com/foo.mjs"`, or `"./bar.mjs"`, might look URL-like; for those, the default translation does what you would expect.
-
-In summary, one should not think of `import(x)` as corresponding to `fetch(x)`. Instead, the correspondence is to `fetch(translate(x))`, where the translation algorithm produces the actual URL to be fetched. In this framing, the way to think about import maps is as providing a mechanism for overriding the default mechanism, i.e. customizing the `translate()` function.
-
-This brings some clarity to some common security questions. For example: given an import map which maps the specifier `"https://1.example.com/foo.mjs"` to the URL `<https://2.example.com/bar.mjs>`, should we apply CSP checks to `<https://1.example.com/foo.mjs>` or to `<https://2.example.com/bar.mjs>`? With this framing we can see that we should apply the checks to the post-translation URL `<https://2.example.com/bar.mjs>` which is actually fetched, and not to the pre-translation `"https://1.example.com/foo.mjs"` module specifier.
+See spec's [Security and Privacy](https://wicg.github.io/import-maps/#security-and-privacy) section.
 
 ## Questionnaire answers
 

--- a/Security and Privacy.md
+++ b/Security and Privacy.md
@@ -12,7 +12,7 @@ No. This specification only deals with developer-supplied information, not user-
 
 **Does this specification deal with high-value data?**
 
-No, except insofar as developers who already have access to high-value data can choose to store that data in modules, and this affects how modules can be processed. For that, see the threat model discussion above.
+No, except insofar as developers who already have access to high-value data can choose to store that data in modules, and this affects how modules can be processed. For that, see the threat model discussion in the spec.
 
 **Does this specification introduce new state for an origin that persists across browsing sessions?**
 
@@ -26,13 +26,13 @@ No.
 
 No, is the plan.
 
-There are some open questions about the potential design of HTTPS → HTTPS fallback cases ([example such case](https://github.com/WICG/import-maps/blob/master/README.md#for-user-supplied-packages)), especially when combined with `import:` URLs in contexts like `<link>` or `<img>` that do not respect the same-origin policy. If specified and implemented naïvely, these could give rise to the ability to determine the network status of resources in ways that might be new. See more discussion in [#76](https://github.com/WICG/import-maps/issues/76).
+There are some open questions about the potential design of future work that leverages import maps to support HTTPS → HTTPS fallback cases ([see README for more detail](https://github.com/WICG/import-maps/blob/master/README.md#fallback-support)), especially when combined with another future feature, [`import:` URLs](https://github.com/WICG/import-maps/blob/master/README.md#import-urls), in contexts like `<link>` or `<img>` that do not respect the same-origin policy. If specified and implemented naïvely, these could give rise to the ability to determine the network status of resources in ways that might be new. See more discussion in [#76](https://github.com/WICG/import-maps/issues/76).
 
-However, we will be sure to solve this before finalizing any specification for these features. Note that both HTTPS → HTTPS fallback and `import:` URLs are "advanced" parts of import maps, that may not be part of initial implementations, per the ["Implementation notes" section of the README](./README.md#implementation-notes).
+However, we will be sure to solve this before finalizing any specification for these future features.
 
 **Does this specification enable new script execution/loading mechanisms?**
 
-Not really. This modifies the existing mechanism of JavaScript module imports, and makes [built-in modules](https://github.com/tc39/proposal-javascript-standard-library/) more feasible by allowing them to be polyfilled and virtualized. But it's all squarely inside the JavaScript module system.
+Not really. This modifies the existing mechanism of JavaScript module imports, but as discussed in the spec, it doesn't fundamentally change such loading, instead just providing a translation layer.
 
 **Does this specification allow an origin access to a user’s location?**
 
@@ -72,7 +72,7 @@ No, apart from via the HTTP cache.
 
 **Does this specification have a "Security Considerations" and "Privacy Considerations" section?**
 
-When we have a full specification, we'll be sure to include one, likely drawn from this document!
+[Yes](https://wicg.github.io/import-maps/#security-and-privacy).
 
 **Does this specification allow downgrading default security characteristics?**
 

--- a/spec.bs
+++ b/spec.bs
@@ -414,3 +414,21 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 * [=Fetch an import() module script graph=] will also need to take a [=script=] instead of a base URL.
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
+
+<h2 id="security-and-privacy">Security and Privacy</h2>
+
+<h3 id="threat-model">Threat models</h3>
+
+Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the README's ["Scope" section](https://github.com/WICG/import-maps/blob/master/README.md#scope).) Although it may seem that the ability to change how resources are imported from JavaScript is powerful, there is no extra power really granted here. That is, they only change things which the page author could change already, by manually editing their code to use different URLs, or by adding asynchronous try/catch fallback processing.
+
+We do still need to apply the traditional protections against first-party malicious actors, e.g. CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion.) But there is no fundamentally new capability introduced here, that needs new consideration.
+
+<h3 id="note-on-import-specifiers">A note on import specifiers</h3>
+
+The import specifiers that appear in `import` statements and `import()` expressions are not URLs, and should not be thought of as such.
+
+To date, there has been a of <a spec="html" data-lt="resolve a module specifier">default mechanism</a> for translating those strings into URLs. And indeed, some of the strings, such as `"https://example.com/foo.mjs"`, or `"./bar.mjs"`, might look URL-like; for those, the default translation does what you would expect.
+
+In summary, one should not think of `import(x)` as corresponding to `fetch(x)`. Instead, the correspondence is to `fetch(translate(x))`, where the translation algorithm produces the actual URL to be fetched. In this framing, the way to think about import maps is as providing a mechanism for overriding the default mechanism, i.e. customizing the `translate()` function.
+
+This brings some clarity to some common security questions. For example: given an import map which maps the specifier `"https://1.example.com/foo.mjs"` to the URL `<https://2.example.com/bar.mjs>`, should we apply CSP checks to `<https://1.example.com/foo.mjs>` or to `<https://2.example.com/bar.mjs>`? With this framing we can see that we should apply the checks to the post-translation URL `<https://2.example.com/bar.mjs>` which is actually fetched, and not to the pre-translation `"https://1.example.com/foo.mjs"` module specifier.

--- a/spec.bs
+++ b/spec.bs
@@ -445,6 +445,10 @@ import maps are not persistent, and an import map only affects the Document that
 
 Therefore, the security restrictions applied to Service Workers (beyond those applied to first-party scripts), e.g. the same-origin/secure contexts requirements, are not applied to import maps.
 
+<h4 id="complexity">Time/memory complexity</h4>
+
+To avoid DOS attacks, explosive memory usage or so, import maps are designed to have reasonably bounded time and memory complexity in worst cases and not to be turing complete.
+
 <h3 id="note-on-import-specifiers">A note on import specifiers</h3>
 
 The import specifiers that appear in `import` statements and `import()` expressions are not URLs, and should not be thought of as such.

--- a/spec.bs
+++ b/spec.bs
@@ -421,18 +421,18 @@ Call sites will also need to be updated to account for [=resolve a module specif
 
 <h2 id="security-and-privacy">Security and Privacy</h2>
 
-<h3 id="threat-model">Threat models</h3>
+<h3 id="threat-models">Threat models</h3>
 
 <h4 id="comparison-with-first-party-scripts">Comparison with first-party scripts</h4>
 
-Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the README's ["Scope" section](https://github.com/WICG/import-maps/blob/master/README.md#scope).)
+Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the explainer's ["Scope" section](https://github.com/WICG/import-maps/blob/master/README.md#scope).)
 
-Although it may seem that the ability to change how resources are imported from JavaScript and the capability of rewriting rules are powerful, there is no extra power really granted here, compared with first-party scripts. That is, they only change things which the page author could change already, by manually editing their code to use different URLs, or by adding asynchronous try/catch fallback processing.
+Although it may seem that the ability to change how resources are imported from JavaScript and the capability of rewriting rules are powerful, there is no extra power really granted here, compared with first-party scripts. That is, they only change things which the page author could change already, by manually editing their code to use different URLs.
 
 We do still need to apply the traditional protections against first-party malicious actors, for example:
 
-- CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion)
-- CORS and strict MIME type check ("`application/importmap+json`") are enforced for external import maps.
+- CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion.)
+- CORS and strict MIME type checking (with a new MIME type, "`application/importmap+json`") for external import maps.
 
 But there is no fundamentally new capability introduced here, that needs new consideration.
 
@@ -440,21 +440,20 @@ But there is no fundamentally new capability introduced here, that needs new con
 
 On one hand, the ability of import maps to change how resources are imported looks similar to the ability of Service Workers to intercept and rewrite fetch requests.
 
-On the other hand, import maps have much more restricted scopes than Service Workers;
-import maps are not persistent, and an import map only affects the Document that installs the import map via `<script type="importmap">`.
+On the other hand, import maps have a much more restricted scope than Service Workers. Import maps are not persistent, and an import map only affects the document that installs the import map via `<script type="importmap">`.
 
 Therefore, the security restrictions applied to Service Workers (beyond those applied to first-party scripts), e.g. the same-origin/secure contexts requirements, are not applied to import maps.
 
 <h4 id="complexity">Time/memory complexity</h4>
 
-To avoid DOS attacks, explosive memory usage or so, import maps are designed to have reasonably bounded time and memory complexity in worst cases and not to be turing complete.
+To avoid denial of service attacks, explosive memory usage, and the like, import maps are designed to have reasonably bounded time and memory complexity in the worst cases, and to not be Turing complete.
 
 <h3 id="note-on-import-specifiers">A note on import specifiers</h3>
 
-The import specifiers that appear in `import` statements and `import()` expressions are not URLs, and should not be thought of as such.
+The import specifiers that appear in `import` statements and `import()` expressions are not [=URLs=], and should not be thought of as such.
 
-To date, there has been a of <a spec="html" data-lt="resolve a module specifier">default mechanism</a> for translating those strings into URLs. And indeed, some of the strings, such as `"https://example.com/foo.mjs"`, or `"./bar.mjs"`, might look URL-like; for those, the default translation does what you would expect.
+To date, there has been a <a spec="html" data-lt="resolve a module specifier">default mechanism</a> for translating those strings into URLs. And indeed, some of the strings, such as `"https://example.com/foo.mjs"`, or `"./bar.mjs"`, might look URL-like; for those, the default translation does what you would expect.
 
-In summary, one should not think of `import(x)` as corresponding to `fetch(x)`. Instead, the correspondence is to `fetch(translate(x))`, where the translation algorithm produces the actual URL to be fetched. In this framing, the way to think about import maps is as providing a mechanism for overriding the default mechanism, i.e. customizing the `translate()` function.
+But overall, one should not think of `import(x)` as corresponding to `fetch(x)`. Instead, the correspondence is to `fetch(translate(x))`, where the translation algorithm produces the actual URL to be fetched. In this framing, the way to think about import maps is as providing a mechanism for overriding the default mechanism, i.e. customizing the `translate()` function.
 
 This brings some clarity to some common security questions. For example: given an import map which maps the specifier `"https://1.example.com/foo.mjs"` to the URL `<https://2.example.com/bar.mjs>`, should we apply CSP checks to `<https://1.example.com/foo.mjs>` or to `<https://2.example.com/bar.mjs>`? With this framing we can see that we should apply the checks to the post-translation URL `<https://2.example.com/bar.mjs>` which is actually fetched, and not to the pre-translation `"https://1.example.com/foo.mjs"` module specifier.

--- a/spec.bs
+++ b/spec.bs
@@ -163,6 +163,10 @@ Inside the <a spec="html">prepare a script</a> algorithm, we make the following 
   This is specified similar to the <a spec="html">list of scripts that will execute in order as soon as possible</a>.
 </p>
 
+<p class="note">
+  CSPs are applied to inline import maps at Step 13 of <a spec="html">prepare a script</a>, and to external import maps in [=fetch an import map=], just like applied to classic/module scripts.
+</p>
+
 </div>
 
 <div algorithm>
@@ -419,9 +423,27 @@ Call sites will also need to be updated to account for [=resolve a module specif
 
 <h3 id="threat-model">Threat models</h3>
 
-Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the README's ["Scope" section](https://github.com/WICG/import-maps/blob/master/README.md#scope).) Although it may seem that the ability to change how resources are imported from JavaScript is powerful, there is no extra power really granted here. That is, they only change things which the page author could change already, by manually editing their code to use different URLs, or by adding asynchronous try/catch fallback processing.
+<h4 id="comparison-with-first-party-scripts">Comparison with first-party scripts</h4>
 
-We do still need to apply the traditional protections against first-party malicious actors, e.g. CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion.) But there is no fundamentally new capability introduced here, that needs new consideration.
+Import maps are explicitly designed to be installed by page authors, i.e. those who have the ability to run first-party scripts. (See the README's ["Scope" section](https://github.com/WICG/import-maps/blob/master/README.md#scope).)
+
+Although it may seem that the ability to change how resources are imported from JavaScript and the capability of rewriting rules are powerful, there is no extra power really granted here, compared with first-party scripts. That is, they only change things which the page author could change already, by manually editing their code to use different URLs, or by adding asynchronous try/catch fallback processing.
+
+We do still need to apply the traditional protections against first-party malicious actors, for example:
+
+- CSP to protect against injection vulnerabilities. (See [#105](https://github.com/WICG/import-maps/issues/105) for further discussion)
+- CORS and strict MIME type check ("`application/importmap+json`") are enforced for external import maps.
+
+But there is no fundamentally new capability introduced here, that needs new consideration.
+
+<h4 id="comparison-with-service-workers">Comparison with Service Workers</h4>
+
+On one hand, the ability of import maps to change how resources are imported looks similar to the ability of Service Workers to intercept and rewrite fetch requests.
+
+On the other hand, import maps have much more restricted scopes than Service Workers;
+import maps are not persistent, and an import map only affects the Document that installs the import map via `<script type="importmap">`.
+
+Therefore, the security restrictions applied to Service Workers (beyond those applied to first-party scripts), e.g. the same-origin/secure contexts requirements, are not applied to import maps.
 
 <h3 id="note-on-import-specifiers">A note on import specifiers</h3>
 


### PR DESCRIPTION
Moved from `Security and Privacy.md`, with a couple of additions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/187.html" title="Last updated on Oct 15, 2019, 7:06 AM UTC (592c3a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/187/eacf4ea...hiroshige-g:592c3a5.html" title="Last updated on Oct 15, 2019, 7:06 AM UTC (592c3a5)">Diff</a>