### PR TITLE
Fix definition of "specifier map"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -53,7 +53,7 @@ summary {
 
 <h2 id="definitions">Definitions</h2>
 
-A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=lists=] of [=URLs=].
+A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=URLs=].
 
 A <dfn>import map</dfn> is a [=struct=] with two [=struct/items=]:
 


### PR DESCRIPTION
In 6f99d474e401e5c5b55b476301d984efbbb7b79c, although all algorithms were updated to assume it was a map from strings to URLs, the actual definition still said that it was to lists of URLs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/pull/189.html" title="Last updated on Oct 15, 2019, 7:18 AM UTC (9a30cd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/189/4219bee...9a30cd0.html" title="Last updated on Oct 15, 2019, 7:18 AM UTC (9a30cd0)">Diff</a>