### PR TITLE
Remove fetch scheme restriction in scope keys

### DIFF
--- a/reference-implementation/__tests__/parsing-scope-keys.js
+++ b/reference-implementation/__tests__/parsing-scope-keys.js
@@ -62,7 +62,7 @@ describe('Relative URL scope keys', () => {
 });
 
 describe('Absolute URL scope keys', () => {
-  it('should only accept absolute URL scope keys with fetch schemes', () => {
+  it('should accept all absolute URL scope keys, with or without fetch schemes', () => {
     expectScopes(
       [
         'about:good',
@@ -87,13 +87,13 @@ describe('Absolute URL scope keys', () => {
         'filesystem:http://example.com/good/',
         'http://good/',
         'https://good/',
-        'ftp://good/'
-      ],
+        'ftp://good/',
+        'import:bad',
+        'mailto:bad',
+        'javascript:bad',
+        'wss://ba/'
+       ],
       [
-        'Invalid scope "import:bad". Scope URLs must have a fetch scheme.',
-        'Invalid scope "mailto:bad". Scope URLs must have a fetch scheme.',
-        'Invalid scope "javascript:bad". Scope URLs must have a fetch scheme.',
-        'Invalid scope "wss://ba/". Scope URLs must have a fetch scheme.'
       ]
     );
   });

--- a/reference-implementation/__tests__/parsing-scope-keys.js
+++ b/reference-implementation/__tests__/parsing-scope-keys.js
@@ -92,9 +92,8 @@ describe('Absolute URL scope keys', () => {
         'mailto:bad',
         'javascript:bad',
         'wss://ba/'
-       ],
-      [
-      ]
+      ],
+      []
     );
   });
 

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const { tryURLParse, hasFetchScheme, tryURLLikeSpecifierParse } = require('./utils.js');
+const { tryURLParse, tryURLLikeSpecifierParse } = require('./utils.js');
 
 exports.parseFromString = (input, baseURL) => {
   const parsed = JSON.parse(input);
@@ -89,11 +89,6 @@ function sortAndNormalizeScopes(obj, baseURL) {
     const scopePrefixURL = tryURLParse(scopePrefix, baseURL);
     if (scopePrefixURL === null) {
       console.warn(`Invalid scope "${scopePrefix}" (parsed against base URL "${baseURL}").`);
-      continue;
-    }
-
-    if (!hasFetchScheme(scopePrefixURL)) {
-      console.warn(`Invalid scope "${scopePrefixURL}". Scope URLs must have a fetch scheme.`);
       continue;
     }
 

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -1,9 +1,6 @@
 'use strict';
 const { URL } = require('url');
 
-// https://fetch.spec.whatwg.org/#fetch-scheme
-const FETCH_SCHEMES = new Set(['http', 'https', 'ftp', 'about', 'blob', 'data', 'file', 'filesystem']);
-
 exports.tryURLParse = (string, baseURL) => {
   try {
     return new URL(string, baseURL);
@@ -19,8 +16,4 @@ exports.tryURLLikeSpecifierParse = (specifier, baseURL) => {
 
   const url = exports.tryURLParse(specifier);
   return url;
-};
-
-exports.hasFetchScheme = url => {
-  return FETCH_SCHEMES.has(url.protocol.slice(0, -1));
 };

--- a/spec.bs
+++ b/spec.bs
@@ -332,9 +332,6 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. If |scopePrefixURL| is failure, then:
       1. [=Report a warning to the console=] that the scope prefix URL was not parseable.
       1. [=Continue=].
-    1. If |scopePrefixURL|'s [=url/scheme=] is not a [=fetch scheme=], then:
-      1. [=Report a warning to the console=] that scope prefix URLs must have a fetch scheme.
-      1. [=Continue=].
     1. Let |normalizedScopePrefix| be the [=URL serializer|serialization=] of |scopePrefixURL|.
     1. Set |normalized|[|normalizedScopePrefix|] to the result of [=sorting and normalizing a specifier map=] given |potentialSpecifierMap| and |baseURL|.
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].


### PR DESCRIPTION
Fixes #188.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/190.html" title="Last updated on Oct 15, 2019, 9:30 PM UTC (7c3e4f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/190/4219bee...hiroshige-g:7c3e4f0.html" title="Last updated on Oct 15, 2019, 9:30 PM UTC (7c3e4f0)">Diff</a>