### PR TITLE
Make any errors (invalid URLs etc) throw errors in resolution

### DIFF
--- a/reference-implementation/__tests__/json/parsing-addresses-absolute.json
+++ b/reference-implementation/__tests__/json/parsing-addresses-absolute.json
@@ -51,6 +51,8 @@
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
         "imports": {
+          "unparseable2": null,
+          "unparseable3": null,
           "invalidButParseable1": "https://example.org/",
           "invalidButParseable2": "https://example.com///",
           "prettyNormal": "https://example.net/",

--- a/reference-implementation/__tests__/json/parsing-addresses-invalid.json
+++ b/reference-implementation/__tests__/json/parsing-addresses-invalid.json
@@ -13,7 +13,13 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
-        "imports": {},
+        "imports": {
+          "foo1": null,
+          "foo2": null,
+          "foo3": null,
+          "foo4": null,
+          "foo5": null
+        },
         "scopes": {}
       }
     }

--- a/reference-implementation/__tests__/json/parsing-addresses.json
+++ b/reference-implementation/__tests__/json/parsing-addresses.json
@@ -29,7 +29,11 @@
       },
       "importMapBaseURL": "data:text/html,test",
       "expectedParsedImportMap": {
-        "imports": {},
+        "imports": {
+          "dotSlash": null,
+          "dotDotSlash": null,
+          "slash": null
+        },
         "scopes": {}
       }
     },
@@ -65,7 +69,15 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
-        "imports": {},
+        "imports": {
+          "dotSlash1": null,
+          "dotDotSlash1": null,
+          "dotSlash2": null,
+          "dotDotSlash2": null,
+          "slash2": null,
+          "dotSlash3": null,
+          "dotDotSlash3": null
+        },
         "scopes": {}
       }
     }

--- a/reference-implementation/__tests__/json/parsing-schema-specifier-map.json
+++ b/reference-implementation/__tests__/json/parsing-schema-specifier-map.json
@@ -18,6 +18,12 @@
       },
       "expectedParsedImportMap": {
         "imports": {
+          "null": null,
+          "boolean": null,
+          "number": null,
+          "object": null,
+          "array": null,
+          "array2": null,
           "string": "https://example.com/"
         },
         "scopes": {}

--- a/reference-implementation/__tests__/json/parsing-trailing-slashes.json
+++ b/reference-implementation/__tests__/json/parsing-trailing-slashes.json
@@ -7,7 +7,9 @@
   },
   "importMapBaseURL": "https://base.example/path1/path2/path3",
   "expectedParsedImportMap": {
-    "imports": {},
+    "imports": {
+      "trailer/": null
+    },
     "scopes": {}
   }
 }

--- a/reference-implementation/__tests__/json/resolving-null.json
+++ b/reference-implementation/__tests__/json/resolving-null.json
@@ -1,0 +1,82 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "Entries with errors shouldn't allow fallback",
+  "tests": {
+    "No fallback to less-specific prefixes": {
+      "importMap": {
+        "imports": {
+          "null/": "/1/",
+          "null/b/": null,
+          "null/b/c/": "/1/2/",
+          "invalid-url/": "/1/",
+          "invalid-url/b/": "https://:invalid-url:/",
+          "invalid-url/b/c/": "/1/2/",
+          "without-trailing-slashes/": "/1/",
+          "without-trailing-slashes/b/": "/x",
+          "without-trailing-slashes/b/c/": "/1/2/",
+          "prefix-resolution-error/": "/1/",
+          "prefix-resolution-error/b/": "data:text/javascript,/",
+          "prefix-resolution-error/b/c/": "/1/2/"
+        }
+      },
+      "expectedResults": {
+        "null/x": "https://example.com/1/x",
+        "null/b/x": null,
+        "null/b/c/x": "https://example.com/1/2/x",
+        "invalid-url/x": "https://example.com/1/x",
+        "invalid-url/b/x": null,
+        "invalid-url/b/c/x": "https://example.com/1/2/x",
+        "without-trailing-slashes/x": "https://example.com/1/x",
+        "without-trailing-slashes/b/x": null,
+        "without-trailing-slashes/b/c/x": "https://example.com/1/2/x",
+        "prefix-resolution-error/x": "https://example.com/1/x",
+        "prefix-resolution-error/b/x": null,
+        "prefix-resolution-error/b/c/x": "https://example.com/1/2/x"
+      }
+    },
+    "No fallback to less-specific scopes": {
+      "importMap": {
+        "imports": {
+          "null": "https://example.com/a",
+          "invalid-url": "https://example.com/b",
+          "without-trailing-slashes/": "https://example.com/c/",
+          "prefix-resolution-error/": "https://example.com/d/"
+        },
+        "scopes": {
+          "/js/": {
+            "null": null,
+            "invalid-url": "https://:invalid-url:/",
+            "without-trailing-slashes/": "/x",
+            "prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "null": null,
+        "invalid-url": null,
+        "without-trailing-slashes/x": null,
+        "prefix-resolution-error/x": null
+      }
+    },
+    "No fallback to absolute URL parsing": {
+      "importMap": {
+        "imports": {},
+        "scopes": {
+          "/js/": {
+            "https://example.com/null": null,
+            "https://example.com/invalid-url": "https://:invalid-url:/",
+            "https://example.com/without-trailing-slashes/": "/x",
+            "https://example.com/prefix-resolution-error/": "data:text/javascript,/"
+          }
+        }
+      },
+      "expectedResults": {
+        "https://example.com/null": null,
+        "https://example.com/invalid-url": null,
+        "https://example.com/without-trailing-slashes/x": null,
+        "https://example.com/prefix-resolution-error/x": null
+      }
+    }
+  }
+}

--- a/reference-implementation/__tests__/test.js
+++ b/reference-implementation/__tests__/test.js
@@ -16,6 +16,7 @@ for (const jsonFile of [
   'parsing-scope-keys.json',
   'parsing-specifier-keys.json',
   'parsing-trailing-slashes.json',
+  'resolving-null.json',
   'scopes-exact-vs-prefix.json',
   'scopes.json',
   'tricky-specifiers.json',

--- a/reference-implementation/lib/parser.js
+++ b/reference-implementation/lib/parser.js
@@ -52,18 +52,21 @@ function sortAndNormalizeSpecifierMap(obj, baseURL) {
     if (typeof value !== 'string') {
       console.warn(`Invalid address ${JSON.stringify(value)} for the specifier key "${specifierKey}". ` +
           `Addresses must be strings.`);
+      normalized[normalizedSpecifierKey] = null;
       continue;
     }
 
     const addressURL = tryURLLikeSpecifierParse(value, baseURL);
     if (addressURL === null) {
       console.warn(`Invalid address "${value}" for the specifier key "${specifierKey}".`);
+      normalized[normalizedSpecifierKey] = null;
       continue;
     }
 
     if (specifierKey.endsWith('/') && !addressURL.href.endsWith('/')) {
       console.warn(`Invalid address "${addressURL.href}" for package specifier key "${specifierKey}". ` +
           `Package addresses must end with "/".`);
+      normalized[normalizedSpecifierKey] = null;
       continue;
     }
 

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -34,11 +34,19 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
   for (const [specifierKey, address] of Object.entries(specifierMap)) {
     // Exact-match case
     if (specifierKey === normalizedSpecifier) {
-      return address;
+      if (address === null) {
+        throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
+      } else {
+        return address;
+      }
     }
 
     // Package prefix-match case
-    if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+    else if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+      if (address === null) {
+        throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
+      }
+
       const afterPrefix = normalizedSpecifier.substring(specifierKey.length);
 
       // Enforced by parsing
@@ -48,7 +56,7 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
 
       // This code looks stupid but it follows the spec more exactly and also gives code coverage a chance to shine.
       if (url === null) {
-        return null;
+        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
       }
       return url;
     }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -32,17 +32,24 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
 
 function resolveImportsMatch(normalizedSpecifier, specifierMap) {
   for (const [specifierKey, resolutionResult] of Object.entries(specifierMap)) {
+    // Exact-match case
     if (specifierKey === normalizedSpecifier) {
-      // Exact-match case
       if (resolutionResult === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
       }
+
+      assert(resolutionResult instanceof URL);
+
       return resolutionResult;
-    } else if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
-      // Package prefix-match case
+    }
+
+    // Package prefix-match case
+    if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
       if (resolutionResult === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
       }
+
+      assert(resolutionResult instanceof URL);
 
       const afterPrefix = normalizedSpecifier.substring(specifierKey.length);
 
@@ -54,6 +61,9 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
       if (url === null) {
         throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
       }
+
+      assert(url instanceof URL);
+
       return url;
     }
   }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -31,29 +31,28 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
 };
 
 function resolveImportsMatch(normalizedSpecifier, specifierMap) {
-  for (const [specifierKey, address] of Object.entries(specifierMap)) {
+  for (const [specifierKey, resolutionResult] of Object.entries(specifierMap)) {
     if (specifierKey === normalizedSpecifier) {
       // Exact-match case
-      if (address === null) {
+      if (resolutionResult === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
-      } else {
-        return address;
       }
+      return resolutionResult;
     } else if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
       // Package prefix-match case
-      if (address === null) {
+      if (resolutionResult === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
       }
 
       const afterPrefix = normalizedSpecifier.substring(specifierKey.length);
 
       // Enforced by parsing
-      assert(address.href.endsWith('/'));
+      assert(resolutionResult.href.endsWith('/'));
 
-      const url = tryURLParse(afterPrefix, address);
+      const url = tryURLParse(afterPrefix, resolutionResult);
 
       if (url === null) {
-        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
+        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}" due to a URL parse failure`);
       }
       return url;
     }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -52,7 +52,6 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
 
       const url = tryURLParse(afterPrefix, address);
 
-      // This code looks stupid but it follows the spec more exactly and also gives code coverage a chance to shine.
       if (url === null) {
         throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
       }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -32,17 +32,15 @@ exports.resolve = (specifier, parsedImportMap, scriptURL) => {
 
 function resolveImportsMatch(normalizedSpecifier, specifierMap) {
   for (const [specifierKey, address] of Object.entries(specifierMap)) {
-    // Exact-match case
     if (specifierKey === normalizedSpecifier) {
+      // Exact-match case
       if (address === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
       } else {
         return address;
       }
-    }
-
-    // Package prefix-match case
-    else if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+    } else if (specifierKey.endsWith('/') && normalizedSpecifier.startsWith(specifierKey)) {
+      // Package prefix-match case
       if (address === null) {
         throw new TypeError(`Blocked by a null entry for "${specifierKey}"`);
       }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -52,7 +52,7 @@ function resolveImportsMatch(normalizedSpecifier, specifierMap) {
       const url = tryURLParse(afterPrefix, resolutionResult);
 
       if (url === null) {
-        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}" due to a URL parse failure`);
+        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
       }
       return url;
     }

--- a/spec.bs
+++ b/spec.bs
@@ -53,7 +53,13 @@ summary {
 
 <h2 id="definitions">Definitions</h2>
 
-A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=URLs=].
+A <dfn>resolution result</dfn> is either
+
+* a [=URL=] on success,
+* Fallback, which indicates the resolution algorithm should proceed to next candidates (less specific prefixes, less specific scopes, etc.), or
+* Block, which indicates the resolution algorithm should fail immediately without any fallbacks.
+
+A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=resolution results=].
 
 A <dfn>import map</dfn> is a [=struct=] with two [=struct/items=]:
 
@@ -310,13 +316,16 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. If |normalizedSpecifierKey| is null, then [=continue=].
     1. If |value| is not a [=string=], then:
       1. [=Report a warning to the console=] that addresses must be strings.
+      1. Set |normalized|[|specifierKey|] to Block.
       1. [=Continue=].
     1. Let |addressURL| be the result of [=parsing a URL-like import specifier=] given |value| and |baseURL|.
     1. If |addressURL| is null, then:
       1. [=Report a warning to the console=] that the address was invalid.
+      1. Set |normalized|[|specifierKey|] to Block.
       1. [=Continue=].
     1. If |specifierKey| ends with U+002F (/), and the [=URL serializer|serialization=] of |addressURL| does not end with U+002F (/), then:
       1. [=Report a warning to the console=] that an invalid address was given for the specifier key |specifierKey|; since |specifierKey| ended in a slash, so must the address.
+      1. Set |normalized|[|specifierKey|] to Block.
       1. [=Continue=].
     1. Set |normalized|[|specifierKey|] to |addressURL|.
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
@@ -393,15 +402,22 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 <div algorithm>
   To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier| and a [=specifier map=] |specifierMap|:
 
-  1. For each |specifierKey| → |address| of |specifierMap|,
-    1. If |specifierKey| is |normalizedSpecifier|, then return |address|.
-    1. If |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
-      1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
-      1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
-      1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |address|.
-      1. If |url| is failure, then return null.
-      1. Return |url|.
+
+  1. For each |specifierKey| → |value| of |specifierMap|,
+    1. Let |resolutionResult| be Fallback.
+    1. If |specifierKey| is |normalizedSpecifier|, then set |resolutionResult| to |value|.
+    1. Else if |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
+      1. If |value| is an [=URL=]:
+        1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
+        1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
+        1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |value|.
+        1. If |url| is failure, then set |resolutionResult| to Block. Otherwise, set |resolutionResult| to |url|.
+      1. Otherwise, set |resolutionResult| to |value|.
+    1. If |resolutionResult| is an [=URL=], then |resolutionResult|.
+       If |resolutionResult| is Block, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
+       <p class="note">Otherwise, |resolutionResult| is Fallback, and the algorithm continues to the next entry.</p>
   1. Return null.
+     <p class="note">The caller will fallback to less specific scopes etc., if any.</p>
 </div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -375,7 +375,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 
   - Successfully resolves a specifier to a [=URL=]. This makes the [=resolve a module specifier=] algorithm immediately return that [=URL=].
   - Throws an error. This makes the [=resolve a module specifier=] algorithm rethrow the error, without any further fallbacks.
-  - Fail to resolve, without an error. In this case the algorithm moves on to the next candidate.
+  - Fails to resolve, without an error. In this case the algorithm moves on to the next candidate.
 </div>
 
 <h3 id="new-resolve-algorithm">New "resolve a module specifier"</h3>
@@ -417,7 +417,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
         <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
       1. Assert: |resolutionResult| is a [=URL=].
       1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
-      1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
+      1. Assert: |resolutionResult|, [=URL serializer|serialized=], ends with "`/`", as enforced during [=parse an import map string|parsing=].
       1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |resolutionResult|.
       1. If |url| is failure, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked due to a URL parse failure.
         <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>

--- a/spec.bs
+++ b/spec.bs
@@ -406,19 +406,23 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 <div algorithm>
   To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier| and a [=specifier map=] |specifierMap|:
 
-  1. For each |specifierKey| → |value| of |specifierMap|,
-    1. If |specifierKey| is |normalizedSpecifier|, then set |resolutionResult| to |value|.
-    1. Otherwise, if |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
-      1. If |value| is a [=URL=]:
-        1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
-        1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
-        1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |value|.
-        1. If |url| is failure, then set |resolutionResult| to null. Otherwise, set |resolutionResult| to |url|.
-      1. Otherwise (i.e., if |value| is null), set |resolutionResult| to null.
-    1. Otherwise, [=continue=].
-    1. If |resolutionResult| is a [=URL=], then return |resolutionResult|.
-    1. Otherwise (i.e. |resolutionResult| is null), throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
-       <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
+  1. For each |specifierKey| → |resolutionResult| of |specifierMap|,
+    1. If |specifierKey| is |normalizedSpecifier|, then:
+      1. If |resolutionResult| is null, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by a null entry.
+        <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
+      1. Assert: |resolutionResult| is a [=URL=].
+      1. Return |resolutionResult|.
+    1. If |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
+      1. If |resolutionResult| is null, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by a null entry.
+        <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
+      1. Assert: |resolutionResult| is a [=URL=].
+      1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
+      1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
+      1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |resolutionResult|.
+      1. If |url| is failure, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked due to a URL parse failure.
+        <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
+      1. Assert: |url| is a [=URL=].
+      1. Return |url|.
   1. Return null.
      <p class="note">The [=resolve a module specifier=] algorithm will fallback to a less specific scope or to "`imports`", if possible.</p>
 </div>

--- a/spec.bs
+++ b/spec.bs
@@ -371,13 +371,11 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 <h2 id="resolving">Resolving module specifiers</h2>
 
 <div class="note">
-During [=resolve a module specifier|resolving a module specifier=], the following algorithms check candidate entries of [=specifier maps=], from most-specific to least-specific scopes and to top-level "`imports`", from most-specific to least-specific prefixes.
-For each entry, the result is one of the following:
+  During [=resolve a module specifier|resolving a module specifier=], the following algorithms check candidate entries of [=specifier maps=], from most-specific to least-specific scopes (falling back to top-level "`imports`"), and from most-specific to least-specific prefixes. For each candidate, the result is one of the following:
 
-  - Successfully resolves a specifier to a [=URL=].
-    This makes the [=resolve a module specifier=] algorithm return immediately successfully with the [=URL=].
-  - Throws an error.
-    This makes the [=resolve a module specifier=] algorithm fail immediately, i.e. throw the error, without any further fallbacks.
+  - Successfully resolves a specifier to a [=URL=]. This makes the [=resolve a module specifier=] algorithm immediately return that [=URL=].
+  - Throws an error. This makes the [=resolve a module specifier=] algorithm rethrow the error, without any further fallbacks.
+  - Fail to resolve, without an error. In this case the algorithm moves on to the next candidate.
 </div>
 
 <h3 id="new-resolve-algorithm">New "resolve a module specifier"</h3>
@@ -408,22 +406,21 @@ For each entry, the result is one of the following:
 <div algorithm>
   To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier| and a [=specifier map=] |specifierMap|:
 
-
   1. For each |specifierKey| → |value| of |specifierMap|,
     1. If |specifierKey| is |normalizedSpecifier|, then set |resolutionResult| to |value|.
-    1. Else if |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
+    1. Otherwise, if |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
       1. If |value| is a [=URL=]:
         1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
         1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
         1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |value|.
         1. If |url| is failure, then set |resolutionResult| to null. Otherwise, set |resolutionResult| to |url|.
-      1. Otherwise, set |resolutionResult| to |value|.
-    1. Else, continue.
-    1. If |resolutionResult| is an [=URL=], then return |resolutionResult|.
-    1. Otherwise (i.e. |resolutionResult| is null), then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
-       <p class="note">This terminates the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
+      1. Otherwise (i.e., if |value| is null), set |resolutionResult| to null.
+    1. Otherwise, [=continue=].
+    1. If |resolutionResult| is a [=URL=], then return |resolutionResult|.
+    1. Otherwise (i.e. |resolutionResult| is null), throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
+       <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
   1. Return null.
-     <p class="note">The caller will fallback to less specific scopes or to "`imports`", if any.</p>
+     <p class="note">The [=resolve a module specifier=] algorithm will fallback to a less specific scope or to "`imports`", if possible.</p>
 </div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -53,11 +53,7 @@ summary {
 
 <h2 id="definitions">Definitions</h2>
 
-A <dfn>resolution result</dfn> is either
-
-* a [=URL=] on success,
-* Fallback, which indicates the resolution algorithm should proceed to next candidates (less specific prefixes, less specific scopes, etc.), or
-* Block, which indicates the resolution algorithm should fail immediately without any fallbacks.
+A <dfn>resolution result</dfn> is either a [=URL=] or null.
 
 A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=resolution results=].
 
@@ -316,16 +312,16 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. If |normalizedSpecifierKey| is null, then [=continue=].
     1. If |value| is not a [=string=], then:
       1. [=Report a warning to the console=] that addresses must be strings.
-      1. Set |normalized|[|specifierKey|] to Block.
+      1. Set |normalized|[|specifierKey|] to null.
       1. [=Continue=].
     1. Let |addressURL| be the result of [=parsing a URL-like import specifier=] given |value| and |baseURL|.
     1. If |addressURL| is null, then:
       1. [=Report a warning to the console=] that the address was invalid.
-      1. Set |normalized|[|specifierKey|] to Block.
+      1. Set |normalized|[|specifierKey|] to null.
       1. [=Continue=].
     1. If |specifierKey| ends with U+002F (/), and the [=URL serializer|serialization=] of |addressURL| does not end with U+002F (/), then:
       1. [=Report a warning to the console=] that an invalid address was given for the specifier key |specifierKey|; since |specifierKey| ended in a slash, so must the address.
-      1. Set |normalized|[|specifierKey|] to Block.
+      1. Set |normalized|[|specifierKey|] to null.
       1. [=Continue=].
     1. Set |normalized|[|specifierKey|] to |addressURL|.
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
@@ -374,6 +370,16 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 
 <h2 id="resolving">Resolving module specifiers</h2>
 
+<div class="note">
+During [=resolve a module specifier|resolving a module specifier=], the following algorithms check candidate entries of [=specifier maps=], from most-specific to least-specific scopes and to top-level "`imports`", from most-specific to least-specific prefixes.
+For each entry, the result is one of the following:
+
+  - Successfully resolves a specifier to a [=URL=].
+    This makes the [=resolve a module specifier=] algorithm return immediately successfully with the [=URL=].
+  - Throws an error.
+    This makes the [=resolve a module specifier=] algorithm fail immediately, i.e. throw the error, without any further fallbacks.
+</div>
+
 <h3 id="new-resolve-algorithm">New "resolve a module specifier"</h3>
 
 <div algorithm>
@@ -404,20 +410,20 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 
 
   1. For each |specifierKey| → |value| of |specifierMap|,
-    1. Let |resolutionResult| be Fallback.
     1. If |specifierKey| is |normalizedSpecifier|, then set |resolutionResult| to |value|.
     1. Else if |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=/starts with=] |specifierKey|, then:
-      1. If |value| is an [=URL=]:
+      1. If |value| is a [=URL=]:
         1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
         1. Assert: |afterPrefix| ends with "`/`", as enforced during [=parse an import map string|parsing=].
         1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |value|.
-        1. If |url| is failure, then set |resolutionResult| to Block. Otherwise, set |resolutionResult| to |url|.
+        1. If |url| is failure, then set |resolutionResult| to null. Otherwise, set |resolutionResult| to |url|.
       1. Otherwise, set |resolutionResult| to |value|.
-    1. If |resolutionResult| is an [=URL=], then |resolutionResult|.
-       If |resolutionResult| is Block, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
-       <p class="note">Otherwise, |resolutionResult| is Fallback, and the algorithm continues to the next entry.</p>
+    1. Else, continue.
+    1. If |resolutionResult| is an [=URL=], then return |resolutionResult|.
+    1. Otherwise (i.e. |resolutionResult| is null), then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by an entry in an import map.
+       <p class="note">This terminates the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
   1. Return null.
-     <p class="note">The caller will fallback to less specific scopes etc., if any.</p>
+     <p class="note">The caller will fallback to less specific scopes or to "`imports`", if any.</p>
 </div>
 
 <h3 id="resolving-updates">Updates to other algorithms</h3>


### PR DESCRIPTION
This PR all errors (found either at parsing or resolution time) throw errors at resolution.

Before this PR, errors found at parsing time, namely:

- Non-string values, including `null`, `[]`, etc.
- Invalid URLs
- Entries with keys with trailing `/` and values without trailing `/`

were ignored, allowing fallback to next candidates at resolution time, and thus can't be used as a definitive way to block particular resolution.
After this PR, such entries are kept in specifier maps as entries with `null` value, and cause resolutions fail (without further fallback) by throwing errors.
For thus purpose, this PR changes the type of values of specifier maps to `URL` or `null`.

Also, before this PR, relative URL resolution failures at prefix matching in `#resolve-a-module-specifier` didn't allow fallback to less specific prefixes while allowing fallback to less specific scopes.
This PR makes such errors throw errors, disallowing fallback to less specific prefixes and scopes.

This PR unifies resolution failures into one: throwing an error.
After this PR, all kind of errors throw at resolution time and definitively blocking resolution.
Fallback to less specific scopes occur only when there are no matching entries in a scope.

Fixes #184.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/205.html" title="Last updated on Feb 6, 2020, 9:54 PM UTC (630066c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/205/6cb173d...hiroshige-g:630066c.html" title="Last updated on Feb 6, 2020, 9:54 PM UTC (630066c)">Diff</a>