### PR TITLE
Depcache spec and reference implementation proposal

### DIFF
--- a/reference-implementation/__tests__/helpers/matchers.js
+++ b/reference-implementation/__tests__/helpers/matchers.js
@@ -15,7 +15,7 @@ expect.extend({
     }
 
     received = received.href;
-    expected = (new URL(expected)).href;
+    expected = new URL(expected).href;
 
     const pass = received === expected;
 

--- a/reference-implementation/__tests__/json/depcache.json
+++ b/reference-implementation/__tests__/json/depcache.json
@@ -1,0 +1,42 @@
+{
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "tests": {
+    "Depcache resolution": {
+      "importMap": {
+        "imports": {
+          "a": "/a-1.mjs",
+          "b": "/scope/b-1.mjs"
+        },
+        "scopes": {
+          "/a-1.mjs": {
+            "a": "/a-2.mjs"
+          },
+          "/scope/": {
+            "a": "/scope/a-3.mjs",
+            "b": "./b-2.mjs"
+          }
+        },
+        "depcache": {
+          "/a-1.mjs": ["a"],
+          "/a-2.mjs": ["b"],
+          "/scope/b-1.mjs": ["./b-2.mjs"],
+          "/scope/b-2.mjs": ["a"]
+        }
+      },
+      "tests": {
+        "should trace full depcache": {
+          "baseURL": "https://example.com/scope2/foo.mjs",
+          "expectedDepcache": {
+            "a": [
+              "https://example.com/a-1.mjs",
+              "https://example.com/a-2.mjs",
+              "https://example.com/scope/b-1.mjs",
+              "https://example.com/scope/b-2.mjs",
+              "https://example.com/scope/a-3.mjs"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/reference-implementation/__tests__/json/parsing-addresses-absolute.json
+++ b/reference-implementation/__tests__/json/parsing-addresses-absolute.json
@@ -20,6 +20,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "about": "about:good",
           "blob": "blob:good",
@@ -50,6 +51,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "unparseable2": null,
           "unparseable3": null,

--- a/reference-implementation/__tests__/json/parsing-addresses-invalid.json
+++ b/reference-implementation/__tests__/json/parsing-addresses-invalid.json
@@ -13,6 +13,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "foo1": null,
           "foo2": null,

--- a/reference-implementation/__tests__/json/parsing-addresses.json
+++ b/reference-implementation/__tests__/json/parsing-addresses.json
@@ -3,6 +3,7 @@
   "tests": {
     "should accept strings prefixed with ./, ../, or /": {
       "importMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": "./foo",
           "dotDotSlash": "../foo",
@@ -11,6 +12,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": "https://base.example/path1/path2/foo",
           "dotDotSlash": "https://base.example/path1/foo",
@@ -21,6 +23,7 @@
     },
     "should not accept strings prefixed with ./, ../, or / for data: base URLs": {
       "importMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": "./foo",
           "dotDotSlash": "../foo",
@@ -29,6 +32,7 @@
       },
       "importMapBaseURL": "data:text/html,test",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": null,
           "dotDotSlash": null,
@@ -39,6 +43,7 @@
     },
     "should accept the literal strings ./, ../, or / with no suffix": {
       "importMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": "./",
           "dotDotSlash": "../",
@@ -47,6 +52,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "dotSlash": "https://base.example/path1/path2/",
           "dotDotSlash": "https://base.example/path1/",
@@ -57,6 +63,7 @@
     },
     "should ignore percent-encoded variants of ./, ../, or /": {
       "importMap": {
+        "depcache": {},
         "imports": {
           "dotSlash1": "%2E/",
           "dotDotSlash1": "%2E%2E/",
@@ -69,6 +76,7 @@
       },
       "importMapBaseURL": "https://base.example/path1/path2/path3",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "dotSlash1": null,
           "dotDotSlash1": null,

--- a/reference-implementation/__tests__/json/parsing-schema-normalization.json
+++ b/reference-implementation/__tests__/json/parsing-schema-normalization.json
@@ -5,6 +5,7 @@
     "should normalize empty import maps to have imports and scopes keys": {
       "importMap": {},
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }
@@ -14,6 +15,7 @@
         "scopes": {}
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }
@@ -23,6 +25,7 @@
         "imports": {}
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }

--- a/reference-implementation/__tests__/json/parsing-schema-specifier-map.json
+++ b/reference-implementation/__tests__/json/parsing-schema-specifier-map.json
@@ -17,6 +17,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "null": null,
           "boolean": null,
@@ -36,6 +37,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }

--- a/reference-implementation/__tests__/json/parsing-schema-toplevel.json
+++ b/reference-implementation/__tests__/json/parsing-schema-toplevel.json
@@ -89,6 +89,7 @@
         "scops": {}
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }

--- a/reference-implementation/__tests__/json/parsing-scope-keys.json
+++ b/reference-implementation/__tests__/json/parsing-scope-keys.json
@@ -8,6 +8,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/foo": {}
@@ -23,6 +24,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/foo": {},
@@ -41,6 +43,7 @@
       },
       "importMapBaseURL": "data:text/html,test",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }
@@ -54,6 +57,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/": {},
@@ -69,6 +73,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/foo/bar?baz#qux": {}
@@ -82,6 +87,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/path3": {}
@@ -99,6 +105,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/foo/": {},
@@ -123,6 +130,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/foo//": {
@@ -149,6 +157,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "about:good": {},
@@ -178,6 +187,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {
           "https://base.example/path1/path2/example.org": {},

--- a/reference-implementation/__tests__/json/parsing-specifier-keys.json
+++ b/reference-implementation/__tests__/json/parsing-specifier-keys.json
@@ -10,6 +10,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://base.example/path1/path2/foo": "https://base.example/dotslash",
           "https://base.example/path1/foo": "https://base.example/dotdotslash",
@@ -28,6 +29,7 @@
       },
       "importMapBaseURL": "data:text/html,",
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "./foo": "https://example.com/dotslash",
           "../foo": "https://example.com/dotdotslash",
@@ -45,6 +47,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://base.example/path1/path2/": "https://base.example/dotslash/",
           "https://base.example/path1/": "https://base.example/dotdotslash/",
@@ -60,6 +63,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://base.example/path1/path2/foo/bar?baz#qux": "https://base.example/foo"
         },
@@ -73,6 +77,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {},
         "scopes": {}
       }
@@ -90,6 +95,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "%2E/": "https://base.example/dotSlash1/",
           "%2E%2E/": "https://base.example/dotDotSlash1/",
@@ -111,6 +117,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://base.example/path1/path2/foo//": "https://base.example/foo3"
         },
@@ -135,6 +142,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "about:good": "https://base.example/about",
           "blob:good": "https://base.example/blob",
@@ -164,6 +172,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://example.com:demo": "https://base.example/unparseable2",
           "http://[www.example.com]/": "https://base.example/unparseable3/",
@@ -183,6 +192,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://example.com/aaa": "https://example.com/aaa",
           "https://example.com/a": "https://example.com/a"
@@ -198,6 +208,7 @@
         }
       },
       "expectedParsedImportMap": {
+        "depcache": {},
         "imports": {
           "https://example.com/aaa": "https://example.com/aaa",
           "https://example.com/a": "https://example.com/a"

--- a/reference-implementation/__tests__/json/parsing-trailing-slashes.json
+++ b/reference-implementation/__tests__/json/parsing-trailing-slashes.json
@@ -7,6 +7,7 @@
   },
   "importMapBaseURL": "https://base.example/path1/path2/path3",
   "expectedParsedImportMap": {
+    "depcache": {},
     "imports": {
       "trailer/": null
     },

--- a/reference-implementation/__tests__/test.js
+++ b/reference-implementation/__tests__/test.js
@@ -2,6 +2,7 @@
 const { runTests } = require('./helpers/common-test-helper.js');
 for (const jsonFile of [
   'data-base-url.json',
+  'depcache.json',
   'empty-import-map.json',
   'overlapping-entries.json',
   'packages-via-trailing-slashes.json',

--- a/reference-implementation/lib/depcache.js
+++ b/reference-implementation/lib/depcache.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { resolve } = require('./resolver.js');
+
+// This implementation differs from the specification since the specification
+// implementation integrates closely with the module loading algorithm.
+exports.traceDepcache = traceDepcache;
+function traceDepcache(url, parsedImportMap, visited = new Set()) {
+  const urlString = url.href;
+  if (visited.has(urlString)) {
+    return visited;
+  }
+  visited.add(urlString);
+
+  const dependencies = parsedImportMap.depcache[urlString] || [];
+  for (const dep of dependencies) {
+    console.log(dep);
+    const resolved = resolve(dep, parsedImportMap, url);
+    traceDepcache(resolved, parsedImportMap, visited);
+  }
+  return [...visited];
+}

--- a/spec.bs
+++ b/spec.bs
@@ -30,7 +30,11 @@ spec: html; type: dfn; urlPrefix: https://html.spec.whatwg.org/multipage/
   text: fetch an import() module script graph; url: webappapis.html#fetch-an-import()-module-script-graph
   text: fetch a modulepreload module script graph; url: webappapis.html#fetch-a-modulepreload-module-script-graph
   text: fetch an inline module script graph; url: webappapis.html#fetch-an-inline-module-script-graph
+  text: fetch a single module script; url: webappapis.html#fetch-a-single-module-script
   text: script; url: webappapis.html#concept-script
+
+urlPrefix: https://tc39.github.io/ecma262/#; spec: ECMA-262; type: abstract-op;
+  text: IsArray; url: sec-isarray
 </pre>
 
 <style>
@@ -57,12 +61,15 @@ A <dfn>resolution result</dfn> is either a [=URL=] or null.
 
 A <dfn>specifier map</dfn> is an [=ordered map=] from [=strings=] to [=resolution results=].
 
-A <dfn>import map</dfn> is a [=struct=] with two [=struct/items=]:
+A <dfn>dependency cache list</dfn> is a optimization cache [=list=] of the dependency [=strings=] of a module.
+
+A <dfn>import map</dfn> is a [=struct=] with three [=struct/items=]:
 
 * <dfn for="import map">imports</dfn>, a [=specifier map=], and
 * <dfn for="import map">scopes</dfn>, an [=ordered map=] of [=URLs=] to [=specifier maps=].
+* <dfn for="import map">depcache</dfn>, an [=ordered map=] of [=URLs=] to [=dependency cache lists=].
 
-An <dfn>empty import map</dfn> is an [=/import map=] with its [=import map/imports=] and [=import map/scopes=] both being empty maps.
+An <dfn>empty import map</dfn> is an [=/import map=] with its [=import map/imports=], [=import map/scopes=] and [=import map/depcache=] all being empty maps.
 
 <h2 id="acquiring">Acquiring import maps</h2>
 
@@ -173,7 +180,7 @@ Inside the <a spec="html">prepare a script</a> algorithm, we make the following 
 
 <div algorithm>
   To <dfn export>fetch an import map</dfn> given |url|, |settings object|, and |options|, run the following steps. This algorithm asynchronously returns an [=/import map=] or null.
-  <p class="note">This algorithm is specified consistently with <a spec="html">fetch a single module script</a> steps 5, 7, 8, 9, 10, and 12.1. Particularly, we enforce CORS to avoid leaking the import map contents that shouldn't be accessed.</p>
+  <p class="note">This algorithm is specified consistently with [=fetch a single module script=] steps 5, 7, 8, 9, 10, and 12.1. Particularly, we enforce CORS to avoid leaking the import map contents that shouldn't be accessed.</p>
 
   1. Let |request| be a new [=/request=] whose [=request/url=] is |url|, [=request/destination=] is "`script`", [=request/mode=] is "`cors`", [=request/referrer=] is "`client`", and [=request/client=] is |settings object|.
      <p class="note">Here we use "`script`" as the [=request/destination=], which means the `script-src-elem` CSP directive applies.</p>
@@ -266,9 +273,12 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
   1. If |parsed|["`scopes`"] [=map/exists=], then:
     1. If |parsed|["`scopes`"] is not a [=map=], then throw a {{TypeError}} indicating that the "`scopes`" top-level key must be a JSON object.
     1. Set |sortedAndNormalizedScopes| to the result of [=sorting and normalizing scopes=] given |parsed|["`scopes`"] and |baseURL|.
-  1. If |parsed|'s [=map/get the keys|keys=] [=set/contains=] any items besides "`imports`" or "`scopes`", [=report a warning to the console=] that an invalid top-level key was present in the import map.
+  1. If |parsed|["`depcache`"] [=map/exists=], then:
+    1. If |parsed|["`depcache`"] is not a [=map=], then throw a {{TypeError}} indicating that the "`depcache`" top-level key must be a JSON object.
+    1. Set |normalizedDepcache| to the result of [=normalizing depcache=] given |parsed|["`depcache`"] and |baseURL|.
+  1. If |parsed|'s [=map/get the keys|keys=] [=set/contains=] any items besides "`imports`", "`scopes`" or "`depcache`", [=report a warning to the console=] that an invalid top-level key was present in the import map.
      <p class="note">This can help detect typos. It is not an error, because that would prevent any future extensions from being added backward-compatibly.</p>
-  1. Return the [=/import map=] whose [=import map/imports=] are |sortedAndNormalizedImports| and whose [=import map/scopes=] scopes are |sortedAndNormalizedScopes|.
+  1. Return the [=/import map=] whose [=import map/imports=] are |sortedAndNormalizedImports|, [=import map/scopes=] scopes are |sortedAndNormalizedScopes| and [=import map/depcache=] depcache are |normalizedDepcache|.
 </div>
 
 <div algorithm>
@@ -300,7 +310,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
   ]»
   </xmp>
 
-  and (despite nothing being present in the input) an empty [=map=] for its [=import map/scopes=].
+  and (despite nothing being present in the input) empty [=map=] entries for its [=import map/scopes=] and [=import map/depcache=].
 </div>
 
 <div algorithm>
@@ -340,6 +350,28 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. Let |normalizedScopePrefix| be the [=URL serializer|serialization=] of |scopePrefixURL|.
     1. Set |normalized|[|normalizedScopePrefix|] to the result of [=sorting and normalizing a specifier map=] given |potentialSpecifierMap| and |baseURL|.
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
+</div>
+
+<div algorithm>
+  To <dfn lt="normalize depcache|normalizing depcache">normalize depcache</dfn>, given a [=map=] |originalMap| and a [=URL=] |baseURL|:
+
+  1. Let |normalized| be an empty [=map=].
+  1. [=map/For each=] |module| → |dependencies| of |originalMap|,
+    1. If ![$IsArray$](dependencies), then throw a {{TypeError}} indicating that the value of the depcache for module |module| must be a JSON array.
+    1. Let |moduleURL| be the result of [=URL parser|parsing=] |module| with |baseURL| as the base URL.
+    1. If |moduleURL| is failure, then:
+      1. [=Report a warning to the console=] that the depcache URL was not parseable.
+      1. [=Continue=].
+    1. Let |validDependencies| be true.
+    1. [=list/For each=] |dependency| of |dependencies|,
+      1. If |dependency| is not a Javascript [=string=], then:
+        1. [=Report a warning to the console=] that the depcache list for |moduleURL| is invalid.
+        1. Set _validDependencies_ to false.
+        1. [=Break=].
+    1. If |dependencies| is not [=list/empty=] and |validDependencies| is true, then:
+      1. Let |normalizedModule| be the [=URL serializer|serialization=] of |moduleURL|.
+      1. Set |normalized|[|normalizedModule|] to |dependencies|.
+  1. Return |normalized|.
 </div>
 
 <p class="note">We sort keys/scopes in reverse order, to put `"foo/bar/"` before `"foo/"` so that `"foo/bar/"` has a higher priority than `"foo/"`.</p>
@@ -389,6 +421,12 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. Set |settingsObject| to |referringScript|'s [=script/settings object=].
     1. Set |baseURL| to |referringScript|'s [=script/base URL=].
   1. Let |importMap| be |settingsObject|'s [=environment settings object/import map=].
+  1. Return the result of [=resolve an import map=] given |specifier|, |importMap| and |baseURL|.
+
+</div>
+
+<div algorithm>
+  To <dfn lt="resolve an import map|resolve an import map">resolve an import map</dfn>, given a [=string=] |specifier|, an [=/import map=] |importMap| and a [=URL=] |baseURL|:
   1. Let |baseURLString| be |baseURL|, [=URL serializer|serialized=].
   1. Let |asURL| be the result of [=parsing a URL-like import specifier=] given |specifier| and |baseURL|.
   1. Let |normalizedSpecifier| be the [=URL serializer|serialization=] of |asURL|, if |asURL| is non-null; otherwise, |specifier|.
@@ -435,6 +473,39 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 * [=Fetch an import() module script graph=] will also need to take a [=script=] instead of a base URL.
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
+
+<h2 id="parallelizing">Parallelizing module graphs</h2>
+
+  To parallelize the loading of modules in the import map, a module graph [=dependency cache list=] can be used to provide upfront a cache of module dependencies so they can be loaded in parallel when lazily loaded, without unnecessary requests or extra round trips.
+
+  When this list of dependency hints is provided for a module [=URL=] the algorithm will, on resolution for that module [=URL=], immediately trigger resolution and preloading for each dependency hint provided.
+
+  The behavior of the dependency cache preloader is distinct from the [=fetch a modulepreload module script graph=] preloader in that it immediately iterates all dependency preloads, and does not trigger instantiation since the top-level module instantiation would already be queued.
+
+<h3 id="preloading-dependency-graphs">Preloading dependency graphs</h3>
+
+  The [=preload depcache=] steps below should be included in [=fetch a single module script=], right after step 4 setting moduleMap[url] to "fetching" combining to form an optimizally-terminating graph fetch parallelizing operation, with minimum complexity. Alternatively these steps can be inlined into [=fetch a single module script=] directly. The rationale of this ordering being that dependencies should be triggered for fetching before their parents, even when fetching in parallel.
+
+<div algorithm>
+  To <dfn lt="preload a dependency graph cache|preload depcache">preload a dependency graph cache</dfn>, given a |url|, a |fetch client settings object|, a |destination|, some |options| and a |module map settings object|, run these steps:
+
+  1. Let |urlString| be |url|, [=URL serializer|serialized=].
+  1. Let |moduleMap| be |module map settings object|'s [=module map=].
+  1. If |moduleMap|[|urlString|] is not undefined, return null.
+    <p class="note">null entries in the |moduleMap| for errored modules will also return here.</p>
+  1. Let |importMap| be |module map settings object|'s [=environment settings object/import map=].
+  1. Let |depcache| be |importMap|'s [=import map/depcache=],
+  1. If |depcache| contains an entry for |urlString|, then:
+    1. Let |dependencies| be the [=list=] |depcache|[|urlString|].
+    1. For each |dependency| of |dependencies|,
+      1. Let |resolvedDependencyURL| be the result of [=resolve an import map=] called with |dependency|, |importMap| and |url|.
+      1. If |resolvedDependencyURL| is null, then:
+        1. Throw a {{TypeError}} indicating that |dependency| was a specifier preloaded by the depcache for |urlString|, but was not resolved by |importMap|.
+      1. Perfom the steps of HTML's [=fetch a single module script] with |resolvedDependencyURL|, |fetch client settings object|, |destination|, |options|, |module map settings object|, |url|, and with the top-level module fetch flag unset, without waiting for asynchronous completion.
+        <p class="note">This triggers the recursive fetch preload operations in turn, since this algorithm is in turn called by [=fetch a single module script=].</p>
+</div>
+
+<p class="note">Only dependency preload resolution errors are thrown, not dependency preload instantiation errors. These can be ignored as they will be rethrown appropriately by the top-level module load operation.</p>
 
 <h2 id="security-and-privacy">Security and Privacy</h2>
 


### PR DESCRIPTION
This PR implements the proposal in https://github.com/WICG/import-maps/issues/209, providing an optimal solution to the waterfall problem, while ensuring that import maps remain the source of truth for the graph and optimization for tools that generate them.

Let's keep proposal feedback to the issue, and direct spec feedback to this PR.

The approach I've implemented here is to effectively integrate the depcache check into `fetch a single module script` in the HTML spec, where the natural recursion between those steps and the preload steps perform the graph traversal, while naturally stopping due to the module map existence checks, avoiding the need for visited lists and such.

To support the new `resolve a module specifier` signature, I've separated out the top-level call to it from HTML from the base-level API-like call to it, called `resolve import maps`.

Any changes to the `fetch a single module script` signature in further refactoring can be applied equally to the depcache preload algorithm, although it is worth noting here that the script for depcache preloads doesn't exist at the time of the network request.

Feedback welcome, happy to keep working on this.