### PR TITLE
Fix error in sort and normalize specifier map.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -312,18 +312,18 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
     1. If |normalizedSpecifierKey| is null, then [=continue=].
     1. If |value| is not a [=string=], then:
       1. [=Report a warning to the console=] that addresses must be strings.
-      1. Set |normalized|[|specifierKey|] to null.
+      1. Set |normalized|[|normalizedSpecifierKey|] to null.
       1. [=Continue=].
     1. Let |addressURL| be the result of [=parsing a URL-like import specifier=] given |value| and |baseURL|.
     1. If |addressURL| is null, then:
       1. [=Report a warning to the console=] that the address was invalid.
-      1. Set |normalized|[|specifierKey|] to null.
+      1. Set |normalized|[|normalizedSpecifierKey|] to null.
       1. [=Continue=].
     1. If |specifierKey| ends with U+002F (/), and the [=URL serializer|serialization=] of |addressURL| does not end with U+002F (/), then:
       1. [=Report a warning to the console=] that an invalid address was given for the specifier key |specifierKey|; since |specifierKey| ended in a slash, so must the address.
-      1. Set |normalized|[|specifierKey|] to null.
+      1. Set |normalized|[|normalizedSpecifierKey|] to null.
       1. [=Continue=].
-    1. Set |normalized|[|specifierKey|] to |addressURL|.
+    1. Set |normalized|[|normalizedSpecifierKey|] to |addressURL|.
   1. Return the result of [=map/sorting=] |normalized|, with an entry |a| being less than an entry |b| if |b|'s [=map/key=] is [=code unit less than=] |a|'s [=map/key=].
 </div>
 


### PR DESCRIPTION
In working on an implementation of import maps (a nodejs loader, found [here](https://github.com/node-loader/node-loader-import-maps)), I found what I think is a typo in the spec. The reference implementation deviates from the spec text, and my implementation didn't work until I matched the reference implementation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/joeldenning/import-maps/pull/224.html" title="Last updated on Sep 5, 2020, 1:04 AM UTC (154a93f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/224/aabac10...joeldenning:154a93f.html" title="Last updated on Sep 5, 2020, 1:04 AM UTC (154a93f)">Diff</a>