### PR TITLE
Only apply /-prefix handling to special URL-like specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ This version ensures that import statements for specifiers that start with the s
 
 In general, the point is that the remapping works the same for URL-like imports as for bare imports. Our previous examples changed the resolution of specifiers like `"lodash"`, and thus changed the meaning of `import "lodash"`. Here we're changing the resolution of specifiers like `"/app/helpers.mjs"`, and thus changing the meaning of `import "/app/helpers.mjs"`.
 
+Note that this trailing-slash variant of URL-like specifier mapping only works if the URL-like specifier has a [special scheme](https://url.spec.whatwg.org/#special-scheme): e.g., a mapping of `"data:text/": "/foo"` will not impact the meaning of `import "data:text/javascript,console.log('test')"`, but instead will only impact `import "data:text/"`.
+
 #### Mapping away hashes in script filenames
 
 Script files are often given a unique hash in their filename, to improve cachability. See [this general discussion of the technique](https://jakearchibald.com/2016/caching-best-practices/), or [this more JavaScript- and webpack-focused discussion](https://developers.google.com/web/fundamentals/performance/webpack/use-long-term-caching).

--- a/reference-implementation/__tests__/json/url-specifiers-schemes.json
+++ b/reference-implementation/__tests__/json/url-specifiers-schemes.json
@@ -1,0 +1,45 @@
+{
+  "importMap": {
+    "imports": {
+      "data:text/": "/lib/test-data/",
+      "about:text/": "/lib/test-about/",
+      "blob:text/": "/lib/test-blob/",
+      "blah:text/": "/lib/test-blah/",
+      "http:text/": "/lib/test-http/",
+      "https:text/": "/lib/test-https/",
+      "file:text/": "/lib/test-file/",
+      "ftp:text/": "/lib/test-ftp/",
+      "ws:text/": "/lib/test-ws/",
+      "wss:text/": "/lib/test-wss/"
+    }
+  },
+  "importMapBaseURL": "https://example.com/app/index.html",
+  "baseURL": "https://example.com/js/app.mjs",
+  "name": "URL-like specifiers",
+  "tests": {
+    "Non-special vs. special schemes": {
+      "expectedResults": {
+        "data:text/javascript,console.log('foo')": "data:text/javascript,console.log('foo')",
+        "data:text/": "https://example.com/lib/test-data/",
+        "about:text/foo": "about:text/foo",
+        "about:text/": "https://example.com/lib/test-about/",
+        "blob:text/foo": "blob:text/foo",
+        "blob:text/": "https://example.com/lib/test-blob/",
+        "blah:text/foo": "blah:text/foo",
+        "blah:text/": "https://example.com/lib/test-blah/",
+        "http:text/foo": "https://example.com/lib/test-http/foo",
+        "http:text/": "https://example.com/lib/test-http/",
+        "https:text/foo": "https://example.com/lib/test-https/foo",
+        "https:text/": "https://example.com/lib/test-https/",
+        "ftp:text/foo": "https://example.com/lib/test-ftp/foo",
+        "ftp:text/": "https://example.com/lib/test-ftp/",
+        "file:text/foo": "https://example.com/lib/test-file/foo",
+        "file:text/": "https://example.com/lib/test-file/",
+        "ws:text/foo": "https://example.com/lib/test-ws/foo",
+        "ws:text/": "https://example.com/lib/test-ws/",
+        "wss:text/foo": "https://example.com/lib/test-wss/foo",
+        "wss:text/": "https://example.com/lib/test-wss/"
+      }
+    }
+  }
+}

--- a/reference-implementation/__tests__/json/url-specifiers.json
+++ b/reference-implementation/__tests__/json/url-specifiers.json
@@ -9,7 +9,14 @@
       "/test/": "/lib/url-trailing-slash/",
       "./test/": "/lib/url-trailing-slash-dot/",
       "/test": "/lib/test1.mjs",
-      "../test": "/lib/test2.mjs"
+      "../test": "/lib/test2.mjs",
+      "data:text/": "/lib/test-data/",
+      "about:text/": "/lib/test-about/",
+      "blob:text/": "/lib/test-blob/",
+      "blah:text/": "/lib/test-blah/",
+      "file:text/": "/lib/test-file/",
+      "ftp:text/": "/lib/test-ftp/",
+      "ws:text/": "/lib/test-ws/"
     }
   },
   "importMapBaseURL": "https://example.com/app/index.html",
@@ -46,6 +53,24 @@
     "should use the last entry's address when URL-like specifiers parse to the same absolute URL": {
       "expectedResults": {
         "/test": "https://example.com/lib/test2.mjs"
+      }
+    },
+    "Non-special vs. special schemes": {
+      "expectedResults": {
+        "data:text/javascript,console.log('foo')": "data:text/javascript,console.log('foo')",
+        "data:text/": "https://example.com/lib/test-data/",
+        "about:text/foo": "about:text/foo",
+        "about:text/": "https://example.com/lib/test-about/",
+        "blob:text/foo": "blob:text/foo",
+        "blob:text/": "https://example.com/lib/test-blob/",
+        "blah:text/foo": "blah:text/foo",
+        "blah:text/": "https://example.com/lib/test-blah/",
+        "ftp:text/foo": "https://example.com/lib/test-ftp/foo",
+        "ftp:text/": "https://example.com/lib/test-ftp/",
+        "file:text/foo": "https://example.com/lib/test-file/foo",
+        "file:text/": "https://example.com/lib/test-file/",
+        "ws:text/foo": "https://example.com/lib/test-ws/foo",
+        "ws:text/": "https://example.com/lib/test-ws/"
       }
     }
   }

--- a/reference-implementation/__tests__/json/url-specifiers.json
+++ b/reference-implementation/__tests__/json/url-specifiers.json
@@ -9,14 +9,7 @@
       "/test/": "/lib/url-trailing-slash/",
       "./test/": "/lib/url-trailing-slash-dot/",
       "/test": "/lib/test1.mjs",
-      "../test": "/lib/test2.mjs",
-      "data:text/": "/lib/test-data/",
-      "about:text/": "/lib/test-about/",
-      "blob:text/": "/lib/test-blob/",
-      "blah:text/": "/lib/test-blah/",
-      "file:text/": "/lib/test-file/",
-      "ftp:text/": "/lib/test-ftp/",
-      "ws:text/": "/lib/test-ws/"
+      "../test": "/lib/test2.mjs"
     }
   },
   "importMapBaseURL": "https://example.com/app/index.html",
@@ -53,24 +46,6 @@
     "should use the last entry's address when URL-like specifiers parse to the same absolute URL": {
       "expectedResults": {
         "/test": "https://example.com/lib/test2.mjs"
-      }
-    },
-    "Non-special vs. special schemes": {
-      "expectedResults": {
-        "data:text/javascript,console.log('foo')": "data:text/javascript,console.log('foo')",
-        "data:text/": "https://example.com/lib/test-data/",
-        "about:text/foo": "about:text/foo",
-        "about:text/": "https://example.com/lib/test-about/",
-        "blob:text/foo": "blob:text/foo",
-        "blob:text/": "https://example.com/lib/test-blob/",
-        "blah:text/foo": "blah:text/foo",
-        "blah:text/": "https://example.com/lib/test-blah/",
-        "ftp:text/foo": "https://example.com/lib/test-ftp/foo",
-        "ftp:text/": "https://example.com/lib/test-ftp/",
-        "file:text/foo": "https://example.com/lib/test-file/foo",
-        "file:text/": "https://example.com/lib/test-file/",
-        "ws:text/foo": "https://example.com/lib/test-ws/foo",
-        "ws:text/": "https://example.com/lib/test-ws/"
       }
     }
   }

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -19,5 +19,5 @@ exports.tryURLLikeSpecifierParse = (specifier, baseURL) => {
 };
 
 // https://url.spec.whatwg.org/#special-scheme
-const specialProtocols = new Set(["ftp:", "file:", "http:", "https:", "ws:", "wss:"]);
+const specialProtocols = new Set(['ftp:', 'file:', 'http:', 'https:', 'ws:', 'wss:']);
 exports.isSpecial = url => specialProtocols.has(url.protocol);

--- a/reference-implementation/lib/utils.js
+++ b/reference-implementation/lib/utils.js
@@ -17,3 +17,7 @@ exports.tryURLLikeSpecifierParse = (specifier, baseURL) => {
   const url = exports.tryURLParse(specifier);
   return url;
 };
+
+// https://url.spec.whatwg.org/#special-scheme
+const specialProtocols = new Set(["ftp:", "file:", "http:", "https:", "ws:", "wss:"]);
+exports.isSpecial = url => specialProtocols.has(url.protocol);

--- a/spec.bs
+++ b/spec.bs
@@ -398,9 +398,9 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
   1. Let |normalizedSpecifier| be the [=URL serializer|serialization=] of |asURL|, if |asURL| is non-null; otherwise, |specifier|.
   1. [=map/For each=] |scopePrefix| → |scopeImports| of |importMap|'s [=import map/scopes=],
     1. If |scopePrefix| is |baseURLString|, or if |scopePrefix| ends with U+002F (/) and |baseURLString| [=string/starts with=] |scopePrefix|, then:
-      1. Let |scopeImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier| and |scopeImports|.
+      1. Let |scopeImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier|, |asURL|, and |scopeImports|.
       1. If |scopeImportsMatch| is not null, then return |scopeImportsMatch|.
-  1. Let |topLevelImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier| and |importMap|'s [=import map/imports=].
+  1. Let |topLevelImportsMatch| be the result of [=resolving an imports match=] given |normalizedSpecifier|, |asURL|, and |importMap|'s [=import map/imports=].
   1. If |topLevelImportsMatch| is not null, then return |topLevelImportsMatch|.
   1. <p class="note">At this point, the specifier was able to be turned in to a URL, but it wasn't remapped to anything by |importMap|.</p>
     If |asURL| is not null, then return |asURL|.
@@ -408,7 +408,7 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
 </div>
 
 <div algorithm>
-  To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier| and a [=specifier map=] |specifierMap|:
+  To <dfn lt="resolve an imports match|resolving an imports match">resolve an imports match</dfn>, given a [=string=] |normalizedSpecifier|, a [=URL=] or null |asURL|, and a [=specifier map=] |specifierMap|:
 
   1. For each |specifierKey| → |resolutionResult| of |specifierMap|,
     1. If |specifierKey| is |normalizedSpecifier|, then:
@@ -416,7 +416,13 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
         <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
       1. Assert: |resolutionResult| is a [=URL=].
       1. Return |resolutionResult|.
-    1. If |specifierKey| ends with U+002F (/) and |normalizedSpecifier| [=string/starts with=] |specifierKey|, then:
+    1. If all of the following are true:
+
+      * |specifierKey| ends with U+002F (/),
+      * |normalizedSpecifier| [=string/starts with=] |specifierKey|, and
+      * either |asURL| is null, or |asURL| [=is special=]
+
+      then:
       1. If |resolutionResult| is null, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked by a null entry.
         <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
       1. Assert: |resolutionResult| is a [=URL=].


### PR DESCRIPTION
Closes #166.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/pull/227.html" title="Last updated on Oct 22, 2020, 3:37 PM UTC (1863452)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/227/1443033...1863452.html" title="Last updated on Oct 22, 2020, 3:37 PM UTC (1863452)">Diff</a>