### PR TITLE
Prevent backtracking above /-prefix entries

### DIFF
--- a/reference-implementation/__tests__/json/packages-via-trailing-slashes.json
+++ b/reference-implementation/__tests__/json/packages-via-trailing-slashes.json
@@ -6,7 +6,8 @@
       "lodash-dot": "./node_modules/lodash-es/lodash.js",
       "lodash-dot/": "./node_modules/lodash-es/",
       "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
-      "lodash-dotdot/": "../node_modules/lodash-es/"
+      "lodash-dotdot/": "../node_modules/lodash-es/",
+      "mapped/path/": "https://github.com/WICG/import-maps/issues/207/"
     }
   },
   "importMapBaseURL": "https://example.com/app/index.html",
@@ -37,6 +38,17 @@
       "expectedResults": {
         "underscore/": null,
         "underscore/foo": null
+      }
+    },
+    "backtracking via ..": {
+      "expectedResults": {
+        "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
+        "mapped/path/..": null,
+        "mapped/path/../backtrack": null,
+        "mapped/path/../../backtrack": null,
+        "mapped/path/../../../backtrack": null,
+        "moment/../backtrack": null,
+        "moment/..": null
       }
     }
   }

--- a/reference-implementation/__tests__/json/packages-via-trailing-slashes.json
+++ b/reference-implementation/__tests__/json/packages-via-trailing-slashes.json
@@ -7,6 +7,7 @@
       "lodash-dot/": "./node_modules/lodash-es/",
       "lodash-dotdot": "../node_modules/lodash-es/lodash.js",
       "lodash-dotdot/": "../node_modules/lodash-es/",
+      "mapped/": "https://example.com/",
       "mapped/path/": "https://github.com/WICG/import-maps/issues/207/"
     }
   },
@@ -42,6 +43,7 @@
     },
     "backtracking via ..": {
       "expectedResults": {
+        "mapped/path": "https://example.com/path",
         "mapped/path/": "https://github.com/WICG/import-maps/issues/207/",
         "mapped/path/..": null,
         "mapped/path/../backtrack": null,

--- a/reference-implementation/__tests__/json/url-specifiers.json
+++ b/reference-implementation/__tests__/json/url-specifiers.json
@@ -16,7 +16,7 @@
   "baseURL": "https://example.com/js/app.mjs",
   "name": "URL-like specifiers",
   "tests": {
-    "Ordinal URL-like specifiers": {
+    "Ordinary URL-like specifiers": {
       "expectedResults": {
         "https://example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
         "https://///example.com/lib/foo.mjs": "https://example.com/app/more/bar.mjs",
@@ -46,6 +46,22 @@
     "should use the last entry's address when URL-like specifiers parse to the same absolute URL": {
       "expectedResults": {
         "/test": "https://example.com/lib/test2.mjs"
+      }
+    },
+    "backtracking (relative URLs)": {
+      "expectedResults": {
+        "/test/..": "https://example.com/lib/slash-only/",
+        "/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
+      }
+    },
+    "backtracking (absolute URLs)": {
+      "expectedResults": {
+        "https://example.com/test/..": "https://example.com/lib/slash-only/",
+        "https://example.com/test/../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../backtrack": "https://example.com/lib/slash-only/backtrack",
+        "https://example.com/test/../../../backtrack": "https://example.com/lib/slash-only/backtrack"
       }
     }
   }

--- a/reference-implementation/lib/resolver.js
+++ b/reference-implementation/lib/resolver.js
@@ -61,7 +61,13 @@ function resolveImportsMatch(normalizedSpecifier, asURL, specifierMap) {
       const url = tryURLParse(afterPrefix, resolutionResult);
 
       if (url === null) {
-        throw new TypeError(`Failed to resolve prefix-match relative URL for "${specifierKey}"`);
+        throw new TypeError(`Failed to resolve the specifier "${normalizedSpecifier}" as its after-prefix portion ` +
+                            `"${afterPrefix}" could not be URL-parsed relative to the URL prefix ` +
+                            `"${resolutionResult.href}" mapped to by the prefix "${specifierKey}"`);
+      }
+
+      if (!url.href.startsWith(resolutionResult.href)) {
+        throw new TypeError(`The specifier "${normalizedSpecifier}" backtracks above its prefix "${specifierKey}"`);
       }
 
       assert(url instanceof URL);

--- a/spec.bs
+++ b/spec.bs
@@ -429,9 +429,11 @@ To <dfn>register an import map</dfn> given an {{HTMLScriptElement}} |element|:
       1. Let |afterPrefix| be the portion of |normalizedSpecifier| after the initial |specifierKey| prefix.
       1. Assert: |resolutionResult|, [=URL serializer|serialized=], ends with "`/`", as enforced during [=parse an import map string|parsing=].
       1. Let |url| be the result of [=URL parser|parsing=] |afterPrefix| relative to the base URL |resolutionResult|.
-      1. If |url| is failure, then throw a {{TypeError}} indicating that resolution of |specifierKey| was blocked due to a URL parse failure.
+      1. If |url| is failure, then throw a {{TypeError}} indicating that resolution of |normalizedSpecifier| was blocked since the |afterPrefix| portion could not be URL-parsed relative to the |resolutionResult| mapped to by the |specifierKey| prefix.
         <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
       1. Assert: |url| is a [=URL=].
+      1. If the [=URL serializer|serialization=] of |url| does not [=string/start with=] the [=URL serializer|serialization=] of |resolutionResult|, then throw a {{TypeError}} indicating that resolution of |normalizedSpecifier| was blocked due to it backtracking above its prefix |specifierKey|.
+        <p class="note">This will terminate the entire [=resolve a module specifier=] algorithm, without any further fallbacks.</p>
       1. Return |url|.
   1. Return null.
      <p class="note">The [=resolve a module specifier=] algorithm will fallback to a less specific scope or to "`imports`", if possible.</p>


### PR DESCRIPTION
Closes #207.

Also changes the error message suggestion for a nearby case to be more helpful and accurate.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/pull/229.html" title="Last updated on Dec 2, 2020, 7:05 PM UTC (35de9f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/229/8be56ee...35de9f4.html" title="Last updated on Dec 2, 2020, 7:05 PM UTC (35de9f4)">Diff</a>