### PR TITLE
Discuss interaction with speculative parsing/fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,10 +492,6 @@ document.write(`<script type="importmap">
   }
 }
 </script>`);
-
-// Dynamic import prevents the later-in-the-document <script type="importmap">
-// from having an effect.
-import("foo");
 ```
 
 then the speculative fetches of `https://example.com/foo.mjs` and `https://example.com/bar.mjs` would be wasted, as the newly-written import map would be in effect instead of the one that was seen inline in the HTML.

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ import "https://other.example/bar.mjs";
 
 One interaction to notice here is that browsers which do speculatively parse inline JS modules, but do not support import maps, would probably speculate incorrectly for this example: they might speculatively fetch `https://other.example/bar.mjs`, instead of the `https://example.com/bar.mjs` it is mapped to.
 
-More generally, import map-based speculations can be subject to the same sort of incorrect speculations as other JS module specifier-based speculations. For example, if the contents of `blocking-1.js` were
+More generally, import map-based speculations can be subject to the same sort of mistakes as other speculations. For example, if the contents of `blocking-1.js` were
 
 ```js
 const el = document.createElement("base");


### PR DESCRIPTION
Closes #234.

@annevk, is this what you had in mind?

In terms of what it would affect for normative spec text, I think that (as part of moving import maps into HTML) we'd add `<script type="importmap">` to the list of elements in https://github.com/whatwg/html/pull/5959 which need special treatment, alongside `<base>` and `<meta name="viewport">`.