### PR TITLE
Fix rejection of multiple import maps

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -132,8 +132,11 @@ Inside the <a spec="html">prepare a script</a> algorithm, we make the following 
 - Insert the following step to [=prepare a script=] step 7, under "Determine the script's type as follows:":
   - If the script block's type string is an [=ASCII case-insensitive=] match for the string "`importmap`", <a spec="html">the script's type</a> is "`importmap`".
 - Insert the following step before <a spec="html">prepare a script</a> step 24:
-  - If <a spec="html">the script's type</a> is "`importmap`", and either the element's [=node document=]'s [=Document/acquiring import maps=] is false or the element's [=node document=]'s [=pending import map script=] is non-null, then <a spec="html">queue a task</a> to <a spec="html">fire an event</a> named `error` at the element, and return.
-    <p class="note">In the future we could loosen the constraint of erroring when the [=pending import map script=] is non-null, to allow multiple import maps.</p>
+  - If <a spec="html">the script's type</a> is "`importmap`":
+    1. If the element's [=node document=]'s [=Document/acquiring import maps=] is false, then <a spec="html">queue a task</a> to <a spec="html">fire an event</a> named `error` at the element, and return.
+    1. Set the element's [=node document=]'s [=Document/acquiring import maps=] to false.
+       <p class="note">In the future we could skip setting [=Document/acquiring import maps=] to false, to allow multiple import maps.</p>
+    1. Assert: the element's [=node document=]'s [=Document/pending import map script=] is null.
 - Insert the following case to <a spec="html">prepare a script</a> step 24.6:
   <dl>
     <dt>"`importmap`"</dt>


### PR DESCRIPTION
Previously, we intended to reject second and subsequent import maps by checking whether `node document's pending import map script is non-null`, but this didn't work because after import maps are registered `pending import map script` is cleared.
This PR fixes this by clearing `acquiring import maps` on preparing the first import map, rejecting second and subsequent import maps on preparation with error events.

Alternative considered:
It might be better to set Document's import map to an empty import map on second import map, because it would prevent developers more effectively from depending on the behavior of multiple import maps cases.
However, this was more complicated to specify (e.g. the first import map should be canceled on preparing the second import map and is hard to receive error events).

WPT: https://github.com/web-platform-tests/wpt/pull/27117
Chromium CL: https://chromium-review.googlesource.com/c/chromium/src/+/2618838


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hiroshige-g/import-maps/pull/242.html" title="Last updated on Jan 9, 2021, 12:35 AM UTC (bb85579)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/242/9778be3...hiroshige-g:bb85579.html" title="Last updated on Jan 9, 2021, 12:35 AM UTC (bb85579)">Diff</a>