### PR TITLE
Feature detection using HTMLScriptElement.supports()

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,6 @@ document.write(`<script type="importmap">
 
 then the speculative fetches of `https://example.com/foo.mjs` and `https://example.com/bar.mjs` would be wasted, as the newly-written import map would be in effect instead of the one that was seen inline in the HTML.
 
-
 ## Feature detection
 
 If the browser supports [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
@@ -509,7 +508,6 @@ if (HTMLScriptElement.supports && HTMLScriptElement.supports('importmap')) {
   console.log('Your browser supports import maps.');
 }
 ```
-
 
 ## Alternatives considered
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Or, how to control the behavior of JavaScript imports_
     - [General URL-like specifier remapping](#general-url-like-specifier-remapping)
     - [Mapping away hashes in script filenames](#mapping-away-hashes-in-script-filenames)
     - [Remapping doesn't work for `<script>`](#remapping-doesnt-work-for-script)
+    - [Feature detection](#feature-detection)
   - [Scoping examples](#scoping-examples)
     - [Multiple versions of the same module](#multiple-versions-of-the-same-module)
     - [Scope inheritance](#scope-inheritance)
@@ -281,6 +282,29 @@ would not: in all classes of browsers, it would attempt to fetch `app.mjs` direc
 ```html
 <script type="module">import "./app.mjs";</script>
 ```
+
+### Feature detection
+
+If the browser supports [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
+[supports(type)](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports) method,
+`HTMLScriptElement.supports('importmap')` must return true.
+
+```js
+if (HTMLScriptElement.supports && HTMLScriptElement.supports('importmap')) {
+  console.log('Your browser supports import maps.');
+}
+```
+
+#### Monkeypatch HTMLScriptElement.supports() method in HTML spec
+
+In the HTML spec's [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
+[supports(type)](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports) method, before 
+
+> 3. Return false.
+
+add the following step:
+
+3. If type is "`importmap`", then return true.
 
 ### Scoping examples
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ _Or, how to control the behavior of JavaScript imports_
     - [General URL-like specifier remapping](#general-url-like-specifier-remapping)
     - [Mapping away hashes in script filenames](#mapping-away-hashes-in-script-filenames)
     - [Remapping doesn't work for `<script>`](#remapping-doesnt-work-for-script)
-    - [Feature detection](#feature-detection)
   - [Scoping examples](#scoping-examples)
     - [Multiple versions of the same module](#multiple-versions-of-the-same-module)
     - [Scope inheritance](#scope-inheritance)
@@ -25,6 +24,7 @@ _Or, how to control the behavior of JavaScript imports_
   - [Dynamic import map example](#dynamic-import-map-example)
   - [Scope](#scope)
   - [Interaction with speculative parsing/fetching](#interaction-with-speculative-parsingfetching)
+- [Feature detection](#feature-detection)
 - [Alternatives considered](#alternatives-considered)
   - [The Node.js module resolution algorithm](#the-nodejs-module-resolution-algorithm)
   - [A programmable resolution hook](#a-programmable-resolution-hook)
@@ -283,29 +283,6 @@ would not: in all classes of browsers, it would attempt to fetch `app.mjs` direc
 <script type="module">import "./app.mjs";</script>
 ```
 
-### Feature detection
-
-If the browser supports [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
-[supports(type)](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports) method,
-`HTMLScriptElement.supports('importmap')` must return true.
-
-```js
-if (HTMLScriptElement.supports && HTMLScriptElement.supports('importmap')) {
-  console.log('Your browser supports import maps.');
-}
-```
-
-#### Monkeypatch HTMLScriptElement.supports() method in HTML spec
-
-In the HTML spec's [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
-[supports(type)](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports) method, before 
-
-> 3. Return false.
-
-add the following step:
-
-3. If type is "`importmap`", then return true.
-
 ### Scoping examples
 
 #### Multiple versions of the same module
@@ -519,6 +496,20 @@ document.write(`<script type="importmap">
 ```
 
 then the speculative fetches of `https://example.com/foo.mjs` and `https://example.com/bar.mjs` would be wasted, as the newly-written import map would be in effect instead of the one that was seen inline in the HTML.
+
+
+## Feature detection
+
+If the browser supports [HTMLScriptElement](https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement)'s
+[supports(type)](https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports) method,
+`HTMLScriptElement.supports('importmap')` must return true.
+
+```js
+if (HTMLScriptElement.supports && HTMLScriptElement.supports('importmap')) {
+  console.log('Your browser supports import maps.');
+}
+```
+
 
 ## Alternatives considered
 

--- a/spec.bs
+++ b/spec.bs
@@ -442,6 +442,18 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
+
+<h2 id="monkeypatch-dom-script-supports">Monkeypatch HTMLScriptElement.supports() method</h3>
+
+In the HTML spec's {{HTMLScriptElement}}'s  {{script/supports(type)}} method, before
+
+> 3. Return false.
+
+add the following step:
+
+> 3. If type is "`importmap`", then return true.
+
+
 <h2 id="security-and-privacy">Security and Privacy</h2>
 
 <h3 id="threat-models">Threat models</h3>

--- a/spec.bs
+++ b/spec.bs
@@ -442,17 +442,15 @@ All call sites of HTML's existing <a spec="html">resolve a module specifier</a> 
 
 Call sites will also need to be updated to account for [=resolve a module specifier=] now throwing exceptions, instead of returning failure. (Previously most call sites just turned failures into {{TypeError}}s manually, so this is straightforward.)
 
+<h2 id="monkeypatch-dom-script-supports">Patching the {{HTMLScriptElement/supports()|HTMLScriptElement.supports()}} method</h3>
 
-<h2 id="monkeypatch-dom-script-supports">Monkeypatch HTMLScriptElement.supports() method</h3>
-
-In the HTML spec's {{HTMLScriptElement}}'s  {{script/supports(type)}} method, before
+In the HTML's {{HTMLScriptElement}}'s  {{HTMLScriptElement/supports(type)}} method steps, before
 
 > 3. Return false.
 
 add the following step:
 
 > 3. If type is "`importmap`", then return true.
-
 
 <h2 id="security-and-privacy">Security and Privacy</h2>
 


### PR DESCRIPTION
The HTMLScriptElement.supports() method was introduced by
https://github.com/whatwg/html/pull/7008.
HTMLScriptElement.supports('importmap') must return true when supported.

Fixes https://github.com/WICG/import-maps/issues/171


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/horo-t/import-maps/pull/256.html" title="Last updated on Sep 9, 2021, 7:46 PM UTC (0fed8df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/import-maps/256/a296a42...horo-t:0fed8df.html" title="Last updated on Sep 9, 2021, 7:46 PM UTC (0fed8df)">Diff</a>